### PR TITLE
Fix UI problem caused by empty visits charts

### DIFF
--- a/public/javascripts/bp_ontology_viewer.js
+++ b/public/javascripts/bp_ontology_viewer.js
@@ -364,7 +364,11 @@ jQuery.bioportal.OntologyPage = function(id, location_path, error_string, page_n
   });
 
   jQuery.bioportal.ont_pages["summary"] = new jQuery.bioportal.OntologyPage("summary", "/ontologies/" + jQuery(document).data().bp.ont_viewer.ontology_id + "?p=summary&ajax=true", "Problem retrieving summary", jQuery(document).data().bp.ont_viewer.ontology_name + " - Summary", "Summary", function() {
-    jQuery(document).data().bp.ontChart.init();
+    try {
+      jQuery(document).data().bp.ontChart.init();
+    } catch (err) {
+      console.log("No ontology visits data to display");
+    }
   });
 
   jQuery.bioportal.ont_pages["mappings"] = new jQuery.bioportal.OntologyPage("mappings", "/ontologies/" + jQuery(document).data().bp.ont_viewer.ontology_id + "?p=mappings&ajax=true", "Problem retrieving mappings", jQuery(document).data().bp.ont_viewer.ontology_name + " - Mappings", "Mappings", function() {


### PR DESCRIPTION
When Google analytics is not used on a appliance and the /analytics JSON is empty an uncaught error is raised by bp_ont_chart.js : Uncaught TypeError: Cannot read property 'getContext' of null

This error cause some trouble with the UI (impossible to directly go from the summary tab to the classes tab. A reload of the page is needed) 

So we have just surrounded the ontology visit charts init with try/catch