### PR TITLE
Fix wrong annotator REST API link

### DIFF
--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -719,8 +719,11 @@ function update_annotations_table(rowsArray) {
   }
 
   // Hide columns as necessary
-  if (context_count == 0)
+  if (context_count == 0) {
     annotationsTable.fnSetColumnVis(4, false);
+  } else {
+    annotationsTable.fnSetColumnVis(4, true);
+  }
 
   var match_keys = Object.keys(match_types);
   if (match_keys.length == 1 && match_keys[0] === "")

--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -62,7 +62,7 @@ function get_annotations() {
   params.ontologies = (ont_select.val() === null) ? [] : ont_select.val();
   params.longest_only = jQuery("#longest_only").is(':checked');
   params.exclude_numbers = jQuery("#exclude_numbers").is(':checked');
-  params.whole_word_only = jQuery("#whole_word_only").is(':checked');
+  params.whole_word_only = !jQuery("#match_partial_words").is(':checked');
   params.exclude_synonyms = jQuery("#exclude_synonyms").is(':checked');
   params.ncbo_slice = (("ncbo_slice" in BP_CONFIG) ? BP_CONFIG.ncbo_slice : '');
 

--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -34,7 +34,7 @@ class AnnotatorController < ApplicationController
                 :mappings => params[:mappings],
                 :longest_only => params[:longest_only],
                 :exclude_numbers => params[:exclude_numbers] ||= "false",  # service default is false
-                :whole_word_only => (params[:whole_word_only] == "true") ? "false" : "true",  # service default is true
+                :whole_word_only => params[:whole_word_only] ||= "true", # service default is true
                 :exclude_synonyms => params[:exclude_synonyms] ||= "false",  # service default is false
                 :ncbo_slice => params[:ncbo_slice] || ''
     }

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -27,7 +27,7 @@
       = check_box_tag :exclude_numbers, :all, false, :id => "exclude_numbers"
       = label_tag :exclude_numbers, "Exclude Numbers"
       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-      = check_box_tag :whole_word_only, :all, false, :id => "whole_word_only"
+      = check_box_tag :whole_word_only, :all, false, :id => "match_partial_words"
       = label_tag :whole_word_only, "Match Partial Words"
     %p
       = check_box_tag :exclude_synonyms, :all, false, :id => "exclude_synonyms"


### PR DESCRIPTION
The links "To reproduce these results: " and "Format Results As: JSON" generated by the annotator UI are wrong
When the "Match Partial Words" box is checked, then it generates a link with the parameter whole_word_only sets to true (it would need to be set to false). 
And when the "Match Partial Words" box is unchecked, then it generates a link with the parameter whole_word_only sets to false

It is just a confusion caused by the fact that the parameter has the opposite semantic in the REST API and in the UI

Also fix a bug where the context column stayed hidden if no context was found in the previous annotation request
