### PR TITLE
fix the annotator call to get mappings

### DIFF
--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -55,8 +55,7 @@ function get_annotations() {
   ajax_process_halt();
 
   var params = {},
-    ont_select = jQuery("#ontology_ontologyId"),
-    mappings = [];
+    ont_select = jQuery("#ontology_ontologyId");
 
   params.text = jQuery("#annotation_text").val();
   params.ontologies = (ont_select.val() === null) ? [] : ont_select.val();
@@ -64,6 +63,7 @@ function get_annotations() {
   params.exclude_numbers = jQuery("#exclude_numbers").is(':checked');
   params.whole_word_only = !jQuery("#match_partial_words").is(':checked');
   params.exclude_synonyms = jQuery("#exclude_synonyms").is(':checked');
+  params.expand_mappings = jQuery("#expand_mappings").is(':checked');
   params.ncbo_slice = (("ncbo_slice" in BP_CONFIG) ? BP_CONFIG.ncbo_slice : '');
 
   var maxLevel = parseInt(jQuery("#class_hierarchy_max_level").val());
@@ -82,11 +82,6 @@ function get_annotations() {
   //if (jQuery("#wholeWordOnly:checked").val() !== undefined) {
   //  params.wholeWordOnly = jQuery("#wholeWordOnly:checked").val();
   //}
-
-  jQuery("[name='mappings']:checked").each(function() {
-    mappings.push(jQuery(this).val());
-  });
-  params.mappings = mappings;
 
   if (jQuery("#semantic_types").val() !== null) {
     params.semantic_types = jQuery("#semantic_types").val();

--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -31,7 +31,7 @@ class AnnotatorController < ApplicationController
                 :class_hierarchy_max_level => params[:class_hierarchy_max_level].to_i,
                 :expand_class_hierarchy => params[:class_hierarchy_max_level].to_i > 0,
                 :semantic_types => params[:semantic_types],
-                :mappings => params[:mappings],
+                :expand_mappings => params[:expand_mappings],
                 :longest_only => params[:longest_only],
                 :exclude_numbers => params[:exclude_numbers] ||= "false",  # service default is false
                 :whole_word_only => params[:whole_word_only] ||= "true", # service default is true
@@ -42,19 +42,20 @@ class AnnotatorController < ApplicationController
     start = Time.now
     query = ANNOTATOR_URI
     query += "?text=" + CGI.escape(text_to_annotate)
-    query += "&include=prefLabel"
+    #query += "&include=prefLabel"
+    # Include= prefLabel causes an internal error when retrieving mappings
     query += "&expand_class_hierarchy=true" if options[:class_hierarchy_max_level] > 0
     query += "&class_hierarchy_max_level=" + options[:class_hierarchy_max_level].to_s if options[:class_hierarchy_max_level] > 0
     query += "&ontologies=" + CGI.escape(options[:ontologies].join(',')) unless options[:ontologies].empty?
     query += "&semantic_types=" + options[:semantic_types].join(',') unless options[:semantic_types].empty?
-    query += "&mappings=" + options[:mappings].join(',') unless options[:mappings].empty?
+    query += "&expand_mappings=" + options[:expand_mappings].to_s unless options[:expand_mappings].empty?
     query += "&longest_only=#{options[:longest_only]}"
     query += "&recognizer=#{params[:recognizer]}"
     query += "&exclude_numbers=" + options[:exclude_numbers].to_s unless options[:exclude_numbers].empty?
     query += "&whole_word_only=" + options[:whole_word_only].to_s unless options[:whole_word_only].empty?
     query += "&exclude_synonyms=" + options[:exclude_synonyms].to_s unless options[:exclude_synonyms].empty?
     query += "&ncbo_slice=" + options[:ncbo_slice].to_s unless options[:ncbo_slice].empty?
-
+    
     annotations = parse_json(query) # See application_controller.rb
     #annotations = LinkedData::Client::HTTP.get(query)
     LOG.add :debug, "Retrieved #{annotations.length} annotations: #{Time.now - start}s"

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -21,8 +21,8 @@
       = label_tag :longest_only, "Match Longest Only"
       &nbsp;&nbsp;
       / TODO: When the REST API supports different mapping types, revise this section of the UI.
-      = check_box_tag :mappings, :all, false, :id => "mappings_all"
-      = label_tag :mappings_all, "Include Mappings"
+      = check_box_tag :expand_mappings, :all, false, :id => "expand_mappings"
+      = label_tag :expand_mappings, "Include Mappings"
     %p
       = check_box_tag :exclude_numbers, :all, false, :id => "exclude_numbers"
       = label_tag :exclude_numbers, "Exclude Numbers"


### PR DESCRIPTION
It is expand_mappings=true, not mappings=all
But why using the parameter expand_mappings=true, instead of mappings=true? It is really not intuitive
If I want mappings I probably instinctively will add the mappings=true parameter, but I can't guess that it is "expand_mappings"