### PR TITLE
Fix summary only

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -16,6 +16,9 @@ class SubmissionsController < ApplicationController
 
     @submission = LinkedData::Client::Models::OntologySubmission.new(values: params[:submission])
     @ontology = LinkedData::Client::Models::Ontology.find(@submission.ontology)
+    # Update summaryOnly on ontology object
+    @ontology.summaryOnly = @submission.isRemote.eql?("3")
+    @ontology.update
     @submission_saved = @submission.save
     if !@submission_saved || @submission_saved.errors
       @errors = response_errors(@submission_saved) # see application_controller::response_errors
@@ -24,11 +27,6 @@ class SubmissionsController < ApplicationController
         @errors = ["Please select a main ontology file from your uploaded zip"]
       end
       render "new"
-    else
-      # Update summaryOnly on ontology object
-      @ontology.summaryOnly = @submission.isRemote.eql?("3")
-      @ontology.save
-      redirect_to "/ontologies/success/#{@ontology.acronym}"
     end
   end
 
@@ -45,12 +43,12 @@ class SubmissionsController < ApplicationController
     @ontology = LinkedData::Client::Models::Ontology.get(params[:submission][:ontology])
     submissions = @ontology.explore.submissions
     @submission = submissions.select {|o| o.submissionId == params["id"].to_i}.first
-    @submission.update_from_params(params[:submission])
-    error_response = @submission.update
 
+    @submission.update_from_params(params[:submission])
     # Update summaryOnly on ontology object
     @ontology.summaryOnly = @submission.isRemote.eql?("3")
-    @ontology.save
+    @ontology.update
+    error_response = @submission.update
 
     if error_response
       @errors = response_errors(error_response) # see application_controller::response_errors

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -15,7 +15,7 @@ class SubmissionsController < ApplicationController
     params[:submission][:contact] = params[:submission][:contact].values
 
     @submission = LinkedData::Client::Models::OntologySubmission.new(values: params[:submission])
-    @ontology = LinkedData::Client::Models::Ontology.find(@submission.ontology)
+    @ontology = LinkedData::Client::Models::Ontology.get(params[:submission][:ontology])
     # Update summaryOnly on ontology object
     @ontology.summaryOnly = @submission.isRemote.eql?("3")
     @ontology.update
@@ -25,8 +25,12 @@ class SubmissionsController < ApplicationController
       if @errors[:error][:uploadFilePath] && @errors[:error][:uploadFilePath].first[:options]
         @masterFileOptions = @errors[:error][:uploadFilePath].first[:options]
         @errors = ["Please select a main ontology file from your uploaded zip"]
+      else
+        redirect_to "/ontologies/success/#{@ontology.acronym}"
       end
       render "new"
+    else
+      redirect_to "/ontologies/success/#{@ontology.acronym}"
     end
   end
 


### PR DESCRIPTION
Fix bug where Only Metadata submissions were uploaded before updating the ontology object (that have a summaryOnly attribute). That was preventing us from uploading Metadata Only submissions