### PR TITLE
Fix generation of 'Format results as' links in Annotator

### DIFF
--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -421,7 +421,7 @@ function annotatorFormatLink(param_string, format) {
   if (format !== 'json') {
     query += "&format=" + format;
   }
-  var link = "<a href='" + encodeURI(query) + "' target='_blank'>" + format_map[format] + "</a>";
+  var link = "<a href=\"" + encodeURI(query) + "\" target=\"_blank\">" + format_map[format] + "</a>";
   jQuery("#download_links_" + format.toLowerCase()).html(link);
 }
 


### PR DESCRIPTION
Before it was not working when there was a single quote ( ' ) in the text to annotate. I just changed how the link was declared in the javascript