### PR TITLE
In browse: for SKOS ontologies now display number of individuals

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -73,10 +73,13 @@ class OntologiesController < ApplicationController
 
       if metrics_hash[ont.id]
         o[:class_count] = metrics_hash[ont.id].classes
+        o[:individual_count] = metrics_hash[ont.id].individuals
       else
         o[:class_count] = 0
+        o[:individual_count] = 0
       end
       o[:class_count_formatted] = number_with_delimiter(o[:class_count], :delimiter => ",")
+      o[:individual_count_formatted] = number_with_delimiter(o[:individual_count], :delimiter => ",")
 
       o[:id]               = ont.id
       o[:type]             = ont.viewOf.nil? ? "ontology" : "ontology_view"

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -207,11 +207,20 @@
         </div>
 
         <div class="badges grid-25 grid-parent" ng-if="ontology.submission !== null && ontology.class_count > 0">
-          <a href="/ontologies/{{ontology.acronym}}?p=classes">
+          <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
             <div class="grid-33 badge_grid">
               <div class="badge">
                 <div class="badge_title">classes</div>
                 <div class="badge_count">{{ontology.class_count_formatted}}</div>
+              </div>
+            </div>
+          </a>
+
+          <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 && ontology.format === 'SKOS'">
+            <div class="grid-33 badge_grid">
+              <div class="badge">
+                <div class="badge_title">concepts</div>
+                <div class="badge_count">{{ontology.individual_count_formatted}}</div>
               </div>
             </div>
           </a>


### PR DESCRIPTION
For SKOS ontologies now display number of individuals (representing number of concepts) instead of the number of classes in the browse section