### PR TITLE
A small update of the browse page 

### DIFF
--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -214,10 +214,10 @@
             </div>
           </a>
 
-          <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 && ontology.format === 'SKOS'">
+          <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 ">
             <div class="grid-50 badge_grid">
               <div class="ontology_badge">
-                <div class="badge_title">concepts</div>
+                <div class="badge_title">{{ontology.format === 'SKOS' ? "concepts" : "individuals"}}</div>
                 <div class="badge_count">{{ontology.individual_count_formatted}}</div>
               </div>
             </div>
@@ -247,8 +247,7 @@
   </div>
 </main>
 
-<!-- JS at end (before footer) -->
-<%= javascript_include_tag "application" %>
+
 
 <script>
   jQuery(document).data().bp.ontologies = <%=MultiJson.dump(@ontologies[0..19]).html_safe%>;

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -208,7 +208,7 @@
 
         <div class="badges grid-25 grid-parent" ng-if="ontology.submission !== null && ontology.class_count > 0">
           <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
-            <div class="grid-33 badge_grid">
+            <div class="grid-50 badge_grid">
               <div class="ontology_badge">
                 <div class="badge_title">classes</div>
                 <div class="badge_count">{{ontology.class_count_formatted}}</div>
@@ -226,7 +226,7 @@
           </a>
 
           <a href="/ontologies/{{ontology.acronym}}#projects_content">
-            <div class="grid-33 badge_grid" ng-if="ontology.projects.length > 0">
+            <div class="grid-50 badge_grid" ng-if="ontology.projects.length > 0">
               <div class="ontology_badge">
                 <div class="badge_title">projects</div>
                 <div class="badge_count">{{ontology.projects.length}}</div>
@@ -235,7 +235,7 @@
           </a>
 
           <a href="/ontologies/{{ontology.acronym}}?p=notes">
-            <div class="grid-33 badge_grid" ng-if="ontology.notes.length > 0">
+            <div class="grid-50 badge_grid" ng-if="ontology.notes.length > 0">
               <div class="ontology_badge">
                 <div class="badge_title">notes</div>
                 <div class="badge_count">{{ontology.notes.length}}</div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -142,7 +142,9 @@
           <label for="sort_order">Sort:</label>
           <select ng-model="ontology_sort_order">
             <option value="-popularity" selected="selected">Popular</option>
-            <option value="-class_count">Size</option>
+            <option value="name">Name</option>
+            <option value="-class_count">Classes count</option>
+            <option value="-individual_count">Instances/Concepts count</option>
             <option value="-project_count">Projects</option>
             <option value="-note_count">Notes</option>
             <!-- <option value="ratings">Rating</option> -->

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -219,7 +219,7 @@
           <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 ">
             <div class="grid-50 badge_grid">
               <div class="ontology_badge">
-                <div class="badge_title">{{ontology.format === 'SKOS' ? "concepts" : "individuals"}}</div>
+                <div class="badge_title">{{ontology.format === 'SKOS' ? "concepts" : "instances"}}</div>
                 <div class="badge_count">{{ontology.individual_count_formatted}}</div>
               </div>
             </div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -215,8 +215,8 @@
           </a>
 
           <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 && ontology.format === 'SKOS'">
-            <div class="grid-33 badge_grid">
-              <div class="badge">
+            <div class="grid-50 badge_grid">
+              <div class="ontology_badge">
                 <div class="badge_title">concepts</div>
                 <div class="badge_count">{{ontology.individual_count_formatted}}</div>
               </div>

--- a/public/browse/app.css
+++ b/public/browse/app.css
@@ -152,12 +152,13 @@
   font-size: 11px;
 }
 .badge_grid {
+  padding-bottom: 10px;
   float: right !important;
 }
 .ontology_badge {
   border-radius: 5px;
   text-align: center;
-  max-width: 60px;
+  max-width: 120px;
   height: 45px;
   max-height: 45px;
   border: solid #234979 thin;


### PR DESCRIPTION
# Change log
- Fix badges text overflow, by  making them bigger (from 33% to 50% of the space)
- Pint a badge for the instances (individuals) count and name it "instances" if not SKOS and "concepts" otherwise.
- Sort by Instances/Concepts count 

I hope this contribution will be useful to you
 
# Screenshots
## New badges
### Before
![image](https://user-images.githubusercontent.com/29259906/151342794-2bdc0e80-188b-42c2-a57c-64ea97ee17d1.png)
### After
![image](https://user-images.githubusercontent.com/29259906/151344647-1947c701-5705-4401-86d9-88175c9c882c.png)
## New sort by
### Before
![image](https://user-images.githubusercontent.com/29259906/151346287-b86559a8-2dd4-4179-89e5-e4be87c2bd65.png)
###After
![image](https://user-images.githubusercontent.com/29259906/151346224-ea62dfb4-79aa-4342-8b55-c1b16b2853d0.png)

