### PR TITLE
Refactor: Centralise escaping and unescaping urls / URI.escape obsolete warning on Ruby 2.7+

### DIFF
--- a/app/controllers/annotator_controller.rb
+++ b/app/controllers/annotator_controller.rb
@@ -41,11 +41,11 @@ class AnnotatorController < ApplicationController
 
     start = Time.now
     query = ANNOTATOR_URI
-    query += "?text=" + CGI.escape(text_to_annotate)
+    query += "?text=" + escape(text_to_annotate)
     query += "&include=prefLabel"
     query += "&expand_class_hierarchy=true" if options[:class_hierarchy_max_level] > 0
     query += "&class_hierarchy_max_level=" + options[:class_hierarchy_max_level].to_s if options[:class_hierarchy_max_level] > 0
-    query += "&ontologies=" + CGI.escape(options[:ontologies].join(',')) unless options[:ontologies].empty?
+    query += "&ontologies=" + escape(options[:ontologies].join(',')) unless options[:ontologies].empty?
     query += "&semantic_types=" + options[:semantic_types].join(',') unless options[:semantic_types].empty?
     query += "&mappings=" + options[:mappings].join(',') unless options[:mappings].empty?
     query += "&longest_only=#{options[:longest_only]}"

--- a/app/controllers/annotatorplus_controller.rb
+++ b/app/controllers/annotatorplus_controller.rb
@@ -59,7 +59,7 @@ class AnnotatorplusController < ApplicationController
 
     start = Time.now
     query = ANNOTATOR_URI
-    query += "?text=" + CGI.escape(text_to_annotate)
+    query += "?text=" + escape(text_to_annotate)
     query += "&include=prefLabel"
     query += "&expand_class_hierarchy=true" if options[:class_hierarchy_max_level] > 0
     query += "&class_hierarchy_max_level=" + options[:class_hierarchy_max_level].to_s if options[:class_hierarchy_max_level] > 0
@@ -69,7 +69,7 @@ class AnnotatorplusController < ApplicationController
     query += "&negation=" + options[:negation] unless options[:negation].empty?
     query += "&experiencer=" + options[:experiencer] unless options[:experiencer].empty?
     query += "&temporality=" + options[:temporality] unless options[:temporality].empty?
-    query += "&ontologies=" + CGI.escape(options[:ontologies].join(',')) unless options[:ontologies].empty?
+    query += "&ontologies=" + escape(options[:ontologies].join(',')) unless options[:ontologies].empty?
     query += "&semantic_types=" + options[:semantic_types].join(',') unless options[:semantic_types].empty?
     query += "&semantic_groups=" + options[:semantic_groups].join(',') unless options[:semantic_groups].empty?
     query += "&mappings=" + options[:mappings].join(',') unless options[:mappings].empty?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -250,7 +250,7 @@ class ApplicationController < ActionController::Base
     params_array = []
     params.each do |key,value|
       next if stop_words.include?(key.to_s) || value.nil? || value.empty?
-      params_array << "#{key}=#{CGI.escape(value)}"
+      params_array << "#{key}=#{escape(value)}"
     end
     params_array.empty? ? "" : "#{prefix}#{params_array.join('&')}"
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -686,4 +686,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def escape(url)
+    helpers.escape(url)
+  end
+
+  def unescape(url)
+    helpers.unescape(url)
+  end
 end

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -114,7 +114,7 @@ class ConceptsController < ApplicationController
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
     not_found if @ontology.nil?
 
-    @concept = @ontology.explore.single_class({full: true}, CGI.unescape(params[:conceptid]))
+    @concept = @ontology.explore.single_class({full: true}, unescape(params[:conceptid]))
     not_found if @concept.nil?
 
     if params[:styled].eql?("true")

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -24,7 +24,7 @@ class LoginController < ApplicationController
         redirect = "/"
 
         if session[:redirect]
-          redirect = CGI.unescape(session[:redirect])
+          redirect = unescape(session[:redirect])
         end
 
 

--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -140,7 +140,7 @@ class MappingsController < ApplicationController
     mapping_ids = params[:mappingids].split(",")
     mapping_ids.each do |map_id|
       begin
-        map_uri = "#{MAPPINGS_URL}/#{CGI.escape(map_id)}"
+        map_uri = "#{MAPPINGS_URL}/#{escape(map_id)}"
         result = LinkedData::Client::HTTP.delete(map_uri)
         raise Exception if !result.nil? #&& result["errorCode"]
         successes << map_id

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -132,7 +132,7 @@ class NotesController < ApplicationController
   # Fix noteid parameters with bad prefixes (some application servers, e.g., Apache, NGINX, mangle encoded slashes).
   def clean_note_id(id)
     id = id.match(/\Ahttp:\/\w/) ? id.sub('http:/', 'http://') : id
-    CGI.unescape(id)
+    unescape(id)
   end
 
 end

--- a/app/controllers/recommender_controller.rb
+++ b/app/controllers/recommender_controller.rb
@@ -12,8 +12,8 @@ class RecommenderController < ApplicationController
   #   input = params[:input].strip.gsub("\r\n", " ").gsub("\n", " ")
   #   start = Time.now
   #   query = RECOMMENDER_URI
-  #   query += "?input=" + CGI.escape(input)
-  #   query += "&ontologies=" + CGI.escape(params[:ontologies].join(',')) unless params[:ontologies].nil?
+  #   query += "?input=" + escape(input)
+  #   query += "&ontologies=" + escape(params[:ontologies].join(',')) unless params[:ontologies].nil?
   #   query += "&input_type=" + params[:input_type] unless params[:input_type].nil?
   #   query += "&output_type=" + params[:output_type] unless params[:output_type].nil?
   #   query += "&max_elements_set=" + params[:max_elements_set] unless params[:output_type].nil?

--- a/app/controllers/redirect_controller.rb
+++ b/app/controllers/redirect_controller.rb
@@ -14,7 +14,7 @@ class RedirectController < ApplicationController
         next if ["url", "action", "controller"].include?(param)
         seperator = first_param ? "?" : "&"
         first_param = false
-        params_string += seperator + param + "=" + CGI.escape(value)
+        params_string += seperator + param + "=" + escape(value)
       end
       # Redirect with params intact
       redirect_to params[:url] + params_string, :status=>:moved_permanently

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -52,11 +52,11 @@ class SearchController < ApplicationController
       # Columns: synonym
       json << "|#{(result.synonym || []).join(";")}"
       if params[:id] && params[:id].split(",").length == 1
-        json << "|#{CGI.escape((result.definition || []).join(". "))}#{separator}"
+        json << "|#{escape((result.definition || []).join(". "))}#{separator}"
       else
         json << "|#{result.explore.ontology.name}"
         json << "|#{result.explore.ontology.acronym}"
-        json << "|#{CGI.escape((result.definition || []).join(". "))}#{separator}"
+        json << "|#{escape((result.definition || []).join(". "))}#{separator}"
       end
 
       # Obsolete results go at the end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -4,7 +4,7 @@ class SubmissionsController < ApplicationController
   before_action :authorize_and_redirect, :only=>[:edit,:update,:create,:new]
 
   def new
-    @ontology = LinkedData::Client::Models::Ontology.get(CGI.unescape(params[:ontology_id])) rescue nil
+    @ontology = LinkedData::Client::Models::Ontology.get(unescape(params[:ontology_id])) rescue nil
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology_id]).first unless @ontology
     @submission = @ontology.explore.latest_submission
     @submission ||= LinkedData::Client::Models::OntologySubmission.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -162,7 +162,7 @@ class UsersController < ApplicationController
   end
 
   def unescape_id
-    params[:id] = CGI.unescape(params[:id])
+    params[:id] = unescape(params[:id])
   end
 
   def verify_owner

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,12 +172,12 @@ module ApplicationHelper
       li_id = child.id.eql?("bp_fake_root") ? "bp_fake_root" : short_uuid
 
       if child.id.eql?("bp_fake_root")
-        string << "<li class='active' id='#{li_id}'><a id='#{CGI.escape(child.id)}' href='#' #{active_style}>#{child.prefLabel}</a></li>"
+        string << "<li class='active' id='#{li_id}'><a id='#{escape(child.id)}' href='#' #{active_style}>#{child.prefLabel}</a></li>"
       else
         icons = child.relation_icon(node)
-        string << "<li #{open} id='#{li_id}'><a id='#{CGI.escape(child.id)}' href='/ontologies/#{child.explore.ontology.acronym}/?p=classes&conceptid=#{CGI.escape(child.id)}' #{active_style}> #{child.prefLabel({use_html: true})}</a> #{icons}"
+        string << "<li #{open} id='#{li_id}'><a id='#{escape(child.id)}' href='/ontologies/#{child.explore.ontology.acronym}/?p=classes&conceptid=#{escape(child.id)}' #{active_style}> #{child.prefLabel({use_html: true})}</a> #{icons}"
         if child.hasChildren && !child.expanded?
-          string << "<ul class='ajax'><li id='#{li_id}'><a id='#{CGI.escape(child.id)}' href='/ajax_concepts/#{child.explore.ontology.acronym}/?conceptid=#{CGI.escape(child.id)}&callback=children'>ajax_class</a></li></ul>"
+          string << "<ul class='ajax'><li id='#{li_id}'><a id='#{escape(child.id)}' href='/ajax_concepts/#{child.explore.ontology.acronym}/?conceptid=#{escape(child.id)}&callback=children'>ajax_class</a></li></ul>"
         elsif child.expanded?
           string << "<ul>"
           build_tree(child, string, id)
@@ -414,7 +414,7 @@ module ApplicationHelper
     return "/ontologies/#{ont_acronym}"
   end
   def bp_class_link(cls_id, ont_acronym)
-    return "#{bp_ont_link(ont_acronym)}?p=classes&conceptid=#{URI.escape(cls_id, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}"
+    return "#{bp_ont_link(ont_acronym)}?p=classes&conceptid=#{escape(cls_id)}"
   end
   def get_link_for_cls_ajax(cls_id, ont_acronym, target=nil)
     # Note: bp_ajax_controller.ajax_process_cls will try to resolve class labels.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,11 +28,15 @@ module ApplicationHelper
   end
 
   def encode_param(string)
-    return URI.escape(string, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+    escape(string)
   end
 
-  def escape(string)
-    CGI.escape(string)
+  def escape(url)
+    CGI.escape(url)
+  end
+
+  def unescape(url)
+    CGI.unescape(url)
   end
 
   def clean(string)

--- a/app/helpers/concepts_helper.rb
+++ b/app/helpers/concepts_helper.rb
@@ -54,7 +54,7 @@ module ConceptsHelper
       k = key.to_s if key.kind_of?(Symbol)
       k ||= key
       if k.start_with?("http")
-        label = LinkedData::Client::HTTP.get("/ontologies/#{@ontology.acronym}/properties/#{CGI.escape(k)}/label").label rescue ""
+        label = LinkedData::Client::HTTP.get("/ontologies/#{@ontology.acronym}/properties/#{escape(k)}/label").label rescue ""
         if label.nil? || label.empty?
           k = k.gsub(/.*#/,'')  # greedy regex replace everything up to last '#'
           k = k.gsub(/.*\//,'') # greedy regex replace everything up to last '/'

--- a/app/views/concepts/_biomixer.html.erb
+++ b/app/views/concepts/_biomixer.html.erb
@@ -1,7 +1,7 @@
 <%require 'cgi'%>
 <% user_api_key = session[:user].nil? ? "" : session[:user].apikey %>
 <% rest_domain = $REST_URL.sub(/https?:\/\//, "") %>
-<% src_url = "#{$BIOMIXER_URL}/?mode=embed&embed_mode=paths_to_root&ontology_acronym=#{@ontology.acronym}&full_concept_id=#{CGI.escape(@concept.fullId)}&userapikey=#{user_api_key}&restURLPrefix=#{rest_domain}" %>
+<% src_url = "#{$BIOMIXER_URL}/?mode=embed&embed_mode=paths_to_root&ontology_acronym=#{@ontology.acronym}&full_concept_id=#{escape(@concept.fullId)}&userapikey=#{user_api_key}&restURLPrefix=#{rest_domain}" %>
 <% original_src = @immediate_load ? src_url : "/ajax/loading_spinner"%>
 
 <script>

--- a/app/views/concepts/_child_nodes.html.haml
+++ b/app/views/concepts/_child_nodes.html.haml
@@ -1,8 +1,8 @@
 - output =""
 - for child in @children
   - icons = child.relation_icon(@concept)
-  - output << "<li id='#{short_uuid}'><a id='#{CGI.escape(child.id)}' href='/ontologies/#{child.explore.ontology.acronym}/?p=classes&conceptid=#{CGI.escape(child.id)}'> #{child.prefLabel}</a> #{icons}"
+  - output << "<li id='#{short_uuid}'><a id='#{escape(child.id)}' href='/ontologies/#{child.explore.ontology.acronym}/?p=classes&conceptid=#{escape(child.id)}'> #{child.prefLabel}</a> #{icons}"
   - if child.hasChildren
-    - output << "<ul class='ajax'><li id='#{short_uuid}'><a id='#{CGI.escape(child.id)}' href='/ajax_concepts/#{child.explore.ontology.acronym}/?conceptid=#{CGI.escape(child.id)}&callback=children'>#{child.prefLabel}</a></li></ul>"
+    - output << "<ul class='ajax'><li id='#{short_uuid}'><a id='#{escape(child.id)}' href='/ajax_concepts/#{child.explore.ontology.acronym}/?conceptid=#{escape(child.id)}&callback=children'>#{child.prefLabel}</a></li></ul>"
   - output << "</li>"
 = raw output

--- a/app/views/layouts/_topnav.html.haml
+++ b/app/views/layouts/_topnav.html.haml
@@ -33,7 +33,7 @@
               %div.dropdown-divider
               %h6.dropdown-header Recently Viewed
               - for ont in session[:ontologies]
-                = link_to(ont.ontology_name, "/ontologies/#{ont.ontology_acronym}/?p=classes&conceptid=#{CGI.escape(ont.concept)}", class: "dropdown-item")
+                = link_to(ont.ontology_name, "/ontologies/#{ont.ontology_acronym}/?p=classes&conceptid=#{escape(ont.concept)}", class: "dropdown-item")
               %div.dropdown-divider
             = link_to("Logout", logout_path, class: "dropdown-item")
       -# Support menu

--- a/app/views/mappings/_concept_mappings.html.haml
+++ b/app/views/mappings/_concept_mappings.html.haml
@@ -6,7 +6,7 @@
 
 %div{:style => "padding: 1%; width: 98%"}
   - if session[:user].nil?
-    = link_to "Create New Mapping", "/login?redirect=/ontologies/#{@ontology.acronym}/?p=classes&t=mappings&conceptid=#{CGI.escape(@concept.id)}", :method => :get, :class => "link_button"
+    = link_to "Create New Mapping", "/login?redirect=/ontologies/#{@ontology.acronym}/?p=classes&t=mappings&conceptid=#{escape(@concept.id)}", :method => :get, :class => "link_button"
   - else
     = link_to("Create New Mapping", |
               new_mapping_path(ontology_from: "#{@ontology.id}", conceptid_from: "#{@concept.id}"), |

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -13,10 +13,10 @@
           %tr
             - cls = map.classes.shift
             %td
-              = link_to("#{cls.id}<span href='/ajax/classes/label?ontology=#{cls.links["ontology"]}&concept=#{CGI.escape(cls.id)}' class='get_via_ajax'></span>".html_safe, ontology_path(cls.explore.ontology.acronym, p: "classes", conceptid: cls.id))
+              = link_to("#{cls.id}<span href='/ajax/classes/label?ontology=#{cls.links["ontology"]}&concept=#{escape(cls.id)}' class='get_via_ajax'></span>".html_safe, ontology_path(cls.explore.ontology.acronym, p: "classes", conceptid: cls.id))
             - cls = map.classes.shift
             %td
-              = link_to("#{cls.id}<span href='/ajax/classes/label?ontology=#{cls.links["ontology"]}&concept=#{CGI.escape(cls.id)}' class='get_via_ajax'></span>".html_safe, ontology_path(cls.explore.ontology.acronym, p: "classes", conceptid: cls.id))
+              = link_to("#{cls.id}<span href='/ajax/classes/label?ontology=#{cls.links["ontology"]}&concept=#{escape(cls.id)}' class='get_via_ajax'></span>".html_safe, ontology_path(cls.explore.ontology.acronym, p: "classes", conceptid: cls.id))
             %td
               #{map.source} #{(map.process || {})[:source_name]}
     = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }

--- a/app/views/notes/_list.html.haml
+++ b/app/views/notes/_list.html.haml
@@ -48,7 +48,7 @@
                   / TODO_REV: Handle notes deletion
                   / %input.delete_note_checkbox{"data-applies_to" => note.appliesTo['id'], "data-note_id" => note.id, :id => "delete_#{note.id}", :type => "checkbox"}/
               %td
-                = link_to note.subject, "#{@note_link}#{CGI.escape(note.id)}", :id => "row_#{note.id}", :class => "concept_notes_list_link notes_list_link"
+                = link_to note.subject, "#{@note_link}#{escape(note.id)}", :id => "row_#{note.id}", :class => "concept_notes_list_link notes_list_link"
                 &nbsp;&nbsp;&nbsp;
                 %span{:id => "#{note.id}_row_archived", :style => "font-size: x-small; color: grey;"}
                   - if note.archived

--- a/app/views/notes/_ontology_list.html.haml
+++ b/app/views/notes/_ontology_list.html.haml
@@ -64,7 +64,7 @@
                   / TODO_REV: Handle notes deletion
                   / %input.delete_note_checkbox{"data-applies_to" => note.appliesTo['id'], "data-note_id" => note.id, :id => "delete_#{note.id}", :type => "checkbox"}/
               %td
-                = link_to note.subject, "#{@note_link}#{CGI.escape(note.id)}", :id => "row_#{note.id}", :class => "ont_notes_list_link notes_list_link"
+                = link_to note.subject, "#{@note_link}#{escape(note.id)}", :id => "row_#{note.id}", :class => "ont_notes_list_link notes_list_link"
                 &nbsp;&nbsp;&nbsp;
                 %span{:id => "#{note.id}_row_archived", :style => "font-size: x-small; color: grey;"}
                   - if note.archived
@@ -79,6 +79,6 @@
                 = note.proposal ? get_note_type_text(note.proposal.type) : "Comment"
               %td
                 - if note.relatedClass && note.relatedClass.length > 0
-                  %a{href: "/ontologies/#{@ontology.acronym}?p=classes&conceptid=#{CGI.escape(note.relatedClass.first)}"}= note.relatedClass.first
+                  %a{href: "/ontologies/#{@ontology.acronym}?p=classes&conceptid=#{escape(note.relatedClass.first)}"}= note.relatedClass.first
               %td
                 = DateTime.parse(note.created).strftime("%Y-%m-%d")

--- a/app/views/ontologies/_metadata.html.haml
+++ b/app/views/ontologies/_metadata.html.haml
@@ -68,10 +68,10 @@
     %section.ont-metadata-card.ont-views-card
       %div.ont-section-toolbar
         %header.pb-2.font-weight-bold= "Views of #{@ontology.acronym}"
-        - ont_id_esc = CGI.escape(@ontology.id)
+        - ont_id_esc = escape(@ontology.id)
         -# TODO: I don't think we should have brackets in the URL parameters.
         - if session[:user].nil?
-          %a{href: "/login?redirect=#{URI.escape("/ontologies/new?ontology[viewOf]=#{ont_id_esc}", Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))}", "aria-label": "Create new view", title: "Create new view"}
+          %a{href: "/login?redirect=#{escape("/ontologies/new?ontology[viewOf]=#{ont_id_esc}")}", "aria-label": "Create new view", title: "Create new view"}
             %i.fas.fa-lg.fa-plus-circle{"aria-hidden": "true", style: "margin-left: 0.5rem;"}
         - else
           %a{href: "/ontologies/new?ontology[viewOf]=#{ont_id_esc}"}

--- a/app/views/ontologies/_widgets.html.haml
+++ b/app/views/ontologies/_widgets.html.haml
@@ -84,15 +84,15 @@
           = javascript_include_tag "/javascripts/widgets/form_complete.js"
           Example 1 (start typing the class name to get its full URI)
           %br/
-          %input{:class => "bp_form_complete-#{CGI.escape(@ontology.acronym).sub('-', '%2d')}-uri", :name => "a", :size => "100", :type => "text"}/
+          %input{:class => "bp_form_complete-#{escape(@ontology.acronym).sub('-', '%2d')}-uri", :name => "a", :size => "100", :type => "text"}/
           %br/
           Example 2 (get the ID for a class)
           %br/
-          %input{:class => "bp_form_complete-#{CGI.escape(@ontology.acronym).sub('-', '%2d')}-shortid", :name => "b", :size => "100", :type => "text"}/
+          %input{:class => "bp_form_complete-#{escape(@ontology.acronym).sub('-', '%2d')}-shortid", :name => "b", :size => "100", :type => "text"}/
           %br/
           Example 3 (get the preferred name for a class)
           %br/
-          %input{:class => "bp_form_complete-#{CGI.escape(@ontology.acronym).sub('-', '%2d')}-name", :name => "c", :size => "100", :type => "text"}/
+          %input{:class => "bp_form_complete-#{escape(@ontology.acronym).sub('-', '%2d')}-name", :name => "c", :size => "100", :type => "text"}/
           #form{:style => "display:none;"}
             .enable-lists
               %h2 Step 2: Follow the Instructions
@@ -171,7 +171,7 @@
               %a.btn.btn-info.thickbox{href: "#{get_code_prefix}&inlineId=vis".html_safe} Get code
         %td
           #bp_vis_container
-            <iframe frameborder="0" src="/widgets/visualization?ontology=#{@ontology.acronym}&class=#{CGI.escape(@ontology.explore.classes["collection"].first.id)}&apikey=#{$APIKEY}" width="100%" height="350"></iframe>
+            <iframe frameborder="0" src="/widgets/visualization?ontology=#{@ontology.acronym}&class=#{escape(@ontology.explore.classes["collection"].first.id)}&apikey=#{$APIKEY}" width="100%" height="350"></iframe>
           #vis{:style => "display:none;"}
             %h2 Step 2: Follow the Instructions
             %hr/
@@ -181,7 +181,7 @@
             %pre
               = preserve do
                 :escaped
-                  <iframe frameborder="0" src="/widgets/visualization?ontology=#{@ontology.acronym}&class=#{CGI.escape(@ontology.explore.classes["collection"].first.id)}&apikey=YOUR_API_KEY"></iframe>
+                  <iframe frameborder="0" src="/widgets/visualization?ontology=#{@ontology.acronym}&class=#{escape(@ontology.explore.classes["collection"].first.id)}&apikey=YOUR_API_KEY"></iframe>
             %p
               For more help visit
               %a{:href => "http://bioontology.org/wiki/index.php/NCBO_Widgets#How_to_use_NCBO_Widgets", :target => "_blank"} NCBO Widget Wiki


### PR DESCRIPTION
## Issues

- URI.escape is obsolete on Ruby 2.7+
- In some places, we use URI.escape, and on other CGI.escape
- in application helpers, we have two methods that do the same `escape(string)` and `encode_param(string)`


## Changes

This PR, fix those issues, by centralizing the escaping in only one function called `escape(url)` that uses CGI.escape. Then reuse it everywhere (same for unescaping).
 