### PR TITLE
Feature: Not found message by context 

### DIFF
--- a/app/controllers/ajax_proxy_controller.rb
+++ b/app/controllers/ajax_proxy_controller.rb
@@ -37,7 +37,7 @@ class AjaxProxyController < ApplicationController
   end
 
   def json_class
-    not_found if params[:conceptid].nil? || params[:conceptid].empty?
+    concept_not_found if params[:conceptid].nil? || params[:conceptid].empty?
     params[:ontology] ||= params[:ontologyid]
 
     if params[:ontologyid].to_i > 0
@@ -48,10 +48,10 @@ class AjaxProxyController < ApplicationController
     end
 
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
 
     @concept = @ontology.explore.single_class({}, params[:conceptid])
-    not_found if @concept.nil?
+    concept_not_found(params[:conceptid]) if @concept.nil?
 
     render_json @concept.to_json
   end
@@ -59,7 +59,7 @@ class AjaxProxyController < ApplicationController
 
   def json_ontology
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
     simple_ontology = simplify_ontology_model(@ontology)  # application_controller (cached)
     render_json simple_ontology.to_json
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ require 'ontologies_api_client'
 class ApplicationController < ActionController::Base
   helper :all # include all helpers, all the time
   helper_method :bp_config_json, :current_license, :using_captcha?
-
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_record
   # Pull configuration parameters for REST connection.
   REST_URI = $REST_URL
   API_KEY = $API_KEY
@@ -694,4 +694,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  private
+  def not_found_record(exception)
+    @error_message = exception.message
+    render 'errors/not_found', status: 404
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,13 +82,21 @@ class ApplicationController < ActionController::Base
     user ||= User.new({"id" => 0})
   end
 
-  def not_found
+  def ontology_not_found(ontology_acronym)
+    not_found("Ontology #{ontology_acronym} not found")
+  end
+
+  def concept_not_found(concept_id)
+    not_found("Concept #{concept_id} not found")
+  end
+
+  def not_found(message = '')
     if request.xhr?
-      render plain: "Error: load failed"
+      render plain: message || "Error: load failed"
       return
     end
-    
-    raise ActiveRecord::RecordNotFound.new('Not Found')
+
+    raise ActiveRecord::RecordNotFound.new(message || 'Not Found')
   end
 
   NOTIFICATION_TYPES = { :notes => "CREATE_NOTE_NOTIFICATION", :all => "ALL_NOTIFICATION" }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -233,7 +233,7 @@ class ApplicationController < ActionController::Base
       return
     end
     acronym = BPIDResolver.id_to_acronym(params[:ontology])
-    not_found unless acronym
+    ontology_not_found(acronym) unless acronym
     if class_view
       @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(acronym).first
       concept = get_class(params).first.to_s

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -398,7 +398,7 @@ class ApplicationController < ActionController::Base
         roots = @ontology.explore.roots
         if roots.nil? || roots.empty?
           LOG.add :debug, "Missing roots for #{@ontology.acronym}"
-          not_found
+          not_found("Missing roots for #{@ontology.acronym}")
         end
 
         @root = LinkedData::Client::Models::Class.new(read_only: true)
@@ -411,14 +411,14 @@ class ApplicationController < ActionController::Base
         # Some ontologies have "too many children" at their root. These will not process and are handled here.
         if @concept.nil?
           LOG.add :debug, "Missing class #{root_child.links.self}"
-          not_found
+          not_found("Missing class #{root_child.links.self}")
         end
       else
         # if the id is coming from a param, use that to get concept
         @concept = @ontology.explore.single_class({full: true}, params[:conceptid])
         if @concept.nil? || @concept.errors
           LOG.add :debug, "Missing class #{@ontology.acronym} / #{params[:conceptid]}"
-          not_found
+          not_found("Missing class #{@ontology.acronym} / #{params[:conceptid]}")
         end
 
         # Create the tree
@@ -427,7 +427,7 @@ class ApplicationController < ActionController::Base
           roots = @ontology.explore.roots
           if roots.nil? || roots.empty?
             LOG.add :debug, "Missing roots for #{@ontology.acronym}"
-            not_found
+            not_found("Missing roots for #{@ontology.acronym}")
           end
           if roots.any? {|c| c.id == @concept.id}
             rootNode = roots

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -21,7 +21,7 @@ class ConceptsController < ApplicationController
     if request.xhr?
       display = params[:callback].eql?('load') ? {full: true} : {display: "prefLabel"}
       @concept = @ontology.explore.single_class(display, params[:id])
-      not_found if @concept.nil?
+      concept_not_found(params[:id]) if @concept.nil?
       show_ajax_request # process an ajax call
     else
       # Get the latest 'ready' submission, or fallback to any latest submission
@@ -29,7 +29,7 @@ class ConceptsController < ApplicationController
       @submission = get_ontology_submission_ready(@ontology)  # application_controller
 
       @concept = @ontology.explore.single_class({full: true}, params[:id])
-      not_found if @concept.nil?
+      concept_not_found(params[:id]) if @concept.nil?
 
       show_uri_request # process a full call
       render :file => '/ontologies/visualize', :use_full_path => true, :layout => 'ontology'
@@ -79,7 +79,7 @@ class ConceptsController < ApplicationController
     end
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
     if @ontology.nil?
-      not_found
+      ontology_not_found(params[:ontology])
     else 
       get_class(params)   # application_controller
       render :partial => "ontologies/treeview"
@@ -94,14 +94,14 @@ class ConceptsController < ApplicationController
       return
     end
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
     @root = @ontology.property_tree
     render json: LinkedData::Client::Models::Property.properties_to_hash(@root.children)
   end
 
   # Renders a details pane for a given ontology/concept
   def details
-    not_found if params[:conceptid].nil? || params[:conceptid].empty?
+    concept_not_found('') if params[:conceptid].nil? || params[:conceptid].empty?
 
     if params[:ontology].to_i > 0
       orig_id = params[:ontology]
@@ -112,10 +112,10 @@ class ConceptsController < ApplicationController
     end
 
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
 
     @concept = @ontology.explore.single_class({full: true}, CGI.unescape(params[:conceptid]))
-    not_found if @concept.nil?
+    concept_not_found(CGI.unescape(params[:conceptid])) if @concept.nil?
 
     if params[:styled].eql?("true")
       render :partial => "details", :layout => "partial"
@@ -126,10 +126,10 @@ class ConceptsController < ApplicationController
 
   def biomixer
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
 
     @concept = @ontology.explore.single_class({full: true}, params[:conceptid])
-    not_found if @concept.nil?
+    concept_not_found(params[:conceptid]) if @concept.nil?
 
     @immediate_load = true
 

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -47,7 +47,7 @@ class ConceptsController < ApplicationController
     end
     @ontology = LinkedData::Client::Models::Ontology.find(ont_id)
     @ontology ||= LinkedData::Client::Models::Ontology.find_by_acronym(ont_id).first
-    not_found unless @ontology
+    ontology_not_found(ont_id) unless @ontology
     # Retrieve a class prefLabel or return the class ID (URI)
     # - mappings may contain class URIs that are not in bioportal (e.g. obo-xrefs)
     cls = @ontology.explore.single_class(cls_id)

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -264,7 +264,7 @@ class OntologiesController < ApplicationController
 
     # Note: find_by_acronym includes ontology views
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
-    not_found if @ontology.nil?
+    ontology_not_found(params[:ontology]) if @ontology.nil?
     
     # Handle the case where an ontology is converted to summary only. 
     # See: https://github.com/ncbo/bioportal_web_ui/issues/133.

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,3 +1,5 @@
 <%= content_tag :div, id: "bd", style: "clear: both; text-align: center; margin-top: 100px; margin-bottom: 100px;" do -%>
-	<h1>The page you are looking for wasn't found. Please try again.</h1>
+	<h1>
+		<%= @error_message || "The page you are looking for wasn't found. Please try again." %>
+	</h1>
 <% end -%>


### PR DESCRIPTION
## What
This PR make error messages more descripitf, for the case of `Onotology not found ` , `Class not found` and `Onotology no roots found` errors
## Before

### Missing roots error
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202455333-5bf4f4da-0323-45cc-9c6d-1a3e356cddb0.png">

### Onotology not found error
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202455079-0dc68757-a9bd-45f4-a6dd-07346a7a2cd6.png">


### Class not found
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202455265-5e082600-a58c-4d0e-a0c2-13424a7af8b0.png">



## After


### Missing roots error
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202453815-209fe7f6-f39b-4e41-a96c-024771b99ce7.png">

### Onotology not found error
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202453908-e7033d44-1da0-4f08-851d-6baed7c74431.png">

### Class not found
<img width="2544" alt="image" src="https://user-images.githubusercontent.com/29259906/202454472-2cf7c192-c6f4-4997-9f7a-524cef710747.png">
