### PR TITLE
Code refactoring for issues with class permalinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'stackprof', require: false
 gem 'thin'
 gem 'will_paginate', '~> 3.0'
 
-gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', tag: 'v2.2.2'
+gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', tag: 'v2.2.4'
 
 group :staging, :production do
   # application monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ncbo/ontologies_api_ruby_client.git
-  revision: 2f27e471995765c366241493e0d949b3d731ff82
-  tag: v2.2.2
+  revision: 7331b8372056ea0cf2a33cc0f86fcf6877712bef
+  tag: v2.2.4
   specs:
-    ontologies_api_client (2.2.2)
+    ontologies_api_client (2.2.4)
       activesupport (= 6.1.7.3)
       addressable (~> 2.8)
       excon
@@ -134,7 +134,7 @@ GEM
     eventmachine (1.2.7)
     excon (0.100.0)
     execjs (2.8.1)
-    faraday (2.7.7)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-excon (2.1.0)

--- a/app/assets/javascripts/bp_ontology_viewer.js.erb
+++ b/app/assets/javascripts/bp_ontology_viewer.js.erb
@@ -80,7 +80,6 @@ function displayTree(data) {
   var concept_param = jQuery(document).data().bp.ont_viewer.concept_param;
   var concept_name = jQuery(document).data().bp.ont_viewer.concept_name;
   var metadata_only = jQuery(document).data().bp.ont_viewer.metadata_only;
-  var current_purl = jQuery(document).data().bp.ont_viewer.current_purl;
   var purl_prefix = jQuery(document).data().bp.ont_viewer.purl_prefix;
   var concept_name_title = jQuery(document).data().bp.ont_viewer.concept_name_title;
 

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -147,7 +147,7 @@ class OntologiesController < ApplicationController
       render plain: @concept.to_jsonld, content_type: request.accept and return
     end
 
-    @current_purl = @concept.purl if $PURL_ENABLED
+    @current_purl = @concept.purl if Rails.configuration.settings.purl[:enabled]
     @submission = get_ontology_submission_ready(@ontology)
 
     unless @concept.id == "bp_fake_root"

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -33,8 +33,7 @@
     jQuery(document).data().bp.ont_viewer.concept_param = "#{"conceptid=\#{params[:conceptid]}" unless params[:conceptid].nil? || params[:conceptid].empty?}";
     jQuery(document).data().bp.ont_viewer.concept_name = "#{@concept.prefLabel unless @concept.nil?}";
     jQuery(document).data().bp.ont_viewer.metadata_only = "#{@ontology.summaryOnly}";
-    jQuery(document).data().bp.ont_viewer.current_purl = "#{@current_purl}";
-    jQuery(document).data().bp.ont_viewer.purl_prefix = "#{($PURL_ENABLED ? $PURL_PREFIX+"/"+@ontology.acronym : '')}";
+    jQuery(document).data().bp.ont_viewer.purl_prefix = "#{(Rails.configuration.settings.purl[:enabled] ? Rails.configuration.settings.purl[:prefix]+"/"+@ontology.acronym : '')}";
     jQuery(document).data().bp.ont_viewer.concept_name_title = (jQuery(document).data().bp.ont_viewer.concept_name == "") ?
         "" : " - " + jQuery(document).data().bp.ont_viewer.concept_name;
 
@@ -83,7 +82,7 @@
             = link_to(@submissions.first.id + "/download?apikey=#{get_apikey}", "aria-label": "Download latest version", title: "Download latest version") do
               %i.fas.fa-lg.fa-download{"aria-hidden": true}
           - if details_available
-            - if $PURL_ENABLED
+            - if Rails.configuration.settings.purl[:enabled]
               = link_to(@ontology.purl, "aria-label": "BioPortal PURL", title: "BioPortal PURL", target: "_blank") do
                 %i.fas.fa-lg.fa-link{"aria-hidden": true}
             = link_to(sub.homepage, "aria-label": "Ontology home page", title: "Ontology home page", target: "_blank") do

--- a/app/views/layouts/_ontology_viewer.html.haml
+++ b/app/views/layouts/_ontology_viewer.html.haml
@@ -55,7 +55,7 @@
     %div.modal-dialog.modal-dialog-centered.modal-lg{role: "document"}
       %div.modal-content
         %div.modal-header
-          %h5#classPermalinkLabel.modal-title Permanent link to this class
+          %h5#classPermalinkLabel.modal-title Link to this page
           %button.close{type: "button", "data-dismiss": "modal", "aria-label": "Close"}
             %span{"aria-hidden": "true"} &times;
         %div.modal-body

--- a/app/views/ontologies/_metadata.html.haml
+++ b/app/views/ontologies/_metadata.html.haml
@@ -19,7 +19,7 @@
           %td View of ontology
           %td
             - ont_parent_acronym = @ontology.viewOf.split('/').last
-            - if $PURL_ENABLED
+            - if Rails.configuration.settings.purl[:enabled]
               - ont_url = @ontology.purl.sub(@ontology.acronym, ont_parent_acronym)
             - else
               - ont_url = @ontology.links['ui'].sub(@ontology.acronym, ont_parent_acronym)

--- a/app/views/ontologies/visualize.html.haml
+++ b/app/views/ontologies/visualize.html.haml
@@ -93,7 +93,7 @@
             %li#request_term_top.tab
               %a{:href => "#request_term"}
                 New Term Requests
-          - if $PURL_ENABLED
+          - if Rails.configuration.settings.purl[:enabled]
             = link_to("#classPermalinkModal", class: "class-permalink", title: "Get a permanent link to this class", aria: {label: "Get a permanent link to this class"}, data: {toggle: "modal", current_purl: "#{@current_purl}"}) do
               %i{class: "fas fa-link", aria: {hidden: "true"}}
         #contents

--- a/app/views/ontologies/visualize.html.haml
+++ b/app/views/ontologies/visualize.html.haml
@@ -94,7 +94,9 @@
               %a{:href => "#request_term"}
                 New Term Requests
           - if Rails.configuration.settings.purl[:enabled]
-            = link_to("#classPermalinkModal", class: "class-permalink", title: "Get a permanent link to this class", aria: {label: "Get a permanent link to this class"}, data: {toggle: "modal", current_purl: "#{@current_purl}"}) do
+            = link_to("#classPermalinkModal", class: "class-permalink", title: "Get a link to this page",
+                      aria: {label: "Get a link to this page"},
+                      data: {toggle: "modal", current_purl: "#{@current_purl}"}) do
               %i{class: "fas fa-link", aria: {hidden: "true"}}
         #contents
           #details_content.tab_container= render :partial =>'/concepts/details'

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -10,13 +10,6 @@ $SITE = "BioPortal"
 # The URL for the BioPortal Rails UI (this application)
 $UI_URL = "http://bioportal.bioontology.org"
 
-# If you are running a PURL server to provide URLs for ontologies in your BioPortal instance, enable this option
-$PURL_ENABLED = false
-
-# The PURL URL is generated using this prefix + the abbreviation for an ontology.
-# The PURL URL generation algorithm can be altered in app/models/ontology_wrapper.rb
-$PURL_PREFIX = "http://purl.bioontology.org/ontology"
-
 # Unique string representing the UI's id for use with the BioPortal API
 $API_KEY = ""
 

--- a/config/initializers/ontologies_api_client.rb
+++ b/config/initializers/ontologies_api_client.rb
@@ -3,7 +3,8 @@ require 'ontologies_api_client'
 LinkedData::Client.config do |config|
   config.cache        = $CLIENT_REQUEST_CACHING
   config.rest_url     = $REST_URL
-  config.purl_prefix  = $PURL_PREFIX
+  config.purl_prefix  = Rails.configuration.settings.purl[:prefix]
+  config.purl_host    = Rails.configuration.settings.purl[:host]
   config.debug_client = $DEBUG_RUBY_CLIENT || false
   config.debug_client_keys = $DEBUG_RUBY_CLIENT_KEYS || []
   config.apikey = $API_KEY

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,15 +25,34 @@ shared:
 development:
   links:
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
+  purl:
+    enabled: true
+    host: 'purl.bioontology.org'
+    prefix: 'https://purl.bioontology.org/ontology'
 
 staging:
   links:
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
+  purl:
+    enabled: true
+    host: 'stagepurl.bioontology.org'
+    prefix: 'https://stagepurl.bioontology.org/ontology'
 
 production:
   links:
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
+  purl:
+    enabled: true
+    host: 'purl.bioontology.org'
+    prefix: 'https://purl.bioontology.org/ontology'
 
 appliance:
   links:
     release_notes: 'https://www.bioontology.org/wiki/BioPortal_Virtual_Appliance_Release_Notes'
+  purl:
+    # Set enabled to true if you're running a PURL server to provide PURLs for ontologies and concepts
+    # in your OntoPortal instance
+    enabled: false
+    host: 'purl.example.org'
+    # PURL URLs are generated using the prefix + the ontology acronym
+    prefix: 'https://purl.example.org/ontology'


### PR DESCRIPTION
* Bumps [ontologies_api_client](https://github.com/ncbo/ontologies_api_ruby_client) from 2.2.2 to 2.2.4
* Converts $PURL_ENABLED and $PURL_PREFIX environment variables to YAML configuration in `settings.yml`
* Removes textual references to permalinks in the class Details pane. Resolves #274.