### PR TITLE
Remove $LEGACY_REST_URL environment variable and associated code

### DIFF
--- a/app/controllers/ajax_proxy_controller.rb
+++ b/app/controllers/ajax_proxy_controller.rb
@@ -1,27 +1,26 @@
+# frozen_string_literal: true
+
 require 'open-uri'
 require 'net/http'
 require 'uri'
 require 'cgi'
 
 class AjaxProxyController < ApplicationController
-
-
   def get
-
     page = open(params[:url])
-    content =  page.read
-    render :text => content
-
+    content = page.read
+    render text: content
   end
 
   def json_class
     not_found if params[:conceptid].nil? || params[:conceptid].empty?
     params[:ontology] ||= params[:ontologyid]
 
-    if params[:ontologyid].to_i > 0
-      params_cleanup_new_api()
-      stop_words = ["controller", "action", "ontologyid"]
-      redirect_to "#{request.path}#{params_string_for_redirect(params, stop_words: stop_words)}", :status => :moved_permanently
+    if params[:ontologyid].to_i.positive?
+      params_cleanup_new_api
+      stop_words = %w[controller action ontologyid]
+      redirect_to "#{request.path}#{params_string_for_redirect(params, stop_words: stop_words)}",
+                  status: :moved_permanently
       return
     end
 
@@ -34,7 +33,6 @@ class AjaxProxyController < ApplicationController
     render_json @concept.to_json
   end
 
-
   def json_ontology
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology]).first
     not_found if @ontology.nil?
@@ -43,12 +41,12 @@ class AjaxProxyController < ApplicationController
   end
 
   def loading_spinner
-    render :partial => "loading_spinner"
+    render partial: 'loading_spinner'
   end
 
   private
 
-  def render_json(json, options={})
+  def render_json(json, options = {})
     callback, variable = params[:callback], params[:variable]
     response = begin
       if callback && variable
@@ -61,7 +59,6 @@ class AjaxProxyController < ApplicationController
         json
       end
     end
-    render({plain: response, content_type: "application/json"}.merge(options))
+    render({ plain: response, content_type: 'application/json' }.merge(options))
   end
-
 end

--- a/app/controllers/ajax_proxy_controller.rb
+++ b/app/controllers/ajax_proxy_controller.rb
@@ -14,28 +14,6 @@ class AjaxProxyController < ApplicationController
 
   end
 
-  def jsonp
-    if params[:apikey].nil? || params[:apikey].empty?
-      render_json '{ "error": "Must supply apikey" }'
-      return
-    end
-
-    if params[:path].nil? || params[:path].empty?
-      render_json '{ "error": "Must supply path" }'
-      return
-    end
-
-    url = URI.parse($LEGACY_REST_URL + params[:path])
-    url.port = $REST_PORT.to_i
-    full_path = (url.query.blank?) ? url.path : "#{url.path}?#{url.query}"
-    full_path = full_path.include?("?") ? full_path + "&apikey=#{params[:apikey]}&userapikey=#{params[:userapikey]}" : full_path + "?apikey=#{params[:apikey]}&userapikey=#{params[:userapikey]}"
-    http = Net::HTTP.new(url.host, url.port)
-    headers = { "Accept" => "application/json" }
-    res = http.get(full_path, headers)
-    response = res.code.to_i >= 400 ? { :status => res.code.to_i, :body => res.body }.to_json : res.body
-    render_json response, {:status => 200}
-  end
-
   def json_class
     not_found if params[:conceptid].nil? || params[:conceptid].empty?
     params[:ontology] ||= params[:ontologyid]

--- a/config/bioportal_config_env.rb.sample
+++ b/config/bioportal_config_env.rb.sample
@@ -25,9 +25,6 @@ $ONTOLOBRIDGE_AUTHENTICATION_TOKEN = "Token Uq2pae73ktMtmgjUgtnhEOuHxr9sZeuK"
 # Ontologies for which to enable the new term request (Ontolobridge) tab
 $NEW_TERM_REQUEST_ONTOLOGIES = []
 
-# Legacy REST core service address (BioPortal v3.x and lower)
-$LEGACY_REST_URL = "http://example.org:8080/bioportal"
-
 # Max number of children to return when rendering a tree view
 $MAX_CHILDREN = 2500
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,7 +92,6 @@ Rails.application.routes.draw do
   get '/ajax/mappings/get_concept_table' => 'mappings#get_concept_table'
   get '/ajax/json_ontology' => 'ajax_proxy#json_ontology'
   get '/ajax/json_class' => 'ajax_proxy#json_class'
-  get '/ajax/jsonp' => 'ajax_proxy#jsonp'
   get '/ajax/loading_spinner' => 'ajax_proxy#loading_spinner'
   get '/ajax/notes/delete' => 'notes#destroy'
   get '/ajax/notes/concept_list' => 'notes#show_concept_list'


### PR DESCRIPTION
- Removes the unused `$LEGACY_REST_URL` environment variable (resolves #211)
- Removes the unused `jsonp` method, which referenced `$LEGACY_REST_URL`
- Fixes some RuboCop warnings in `AjaxProxyController`