### PR TITLE
Fix various issues with notes emails subscriptions

### DIFF
--- a/app/assets/javascripts/bp_notes.js
+++ b/app/assets/javascripts/bp_notes.js
@@ -357,10 +357,17 @@ function subscribeToNotes(button) {
       var subbedVal = (isSubbed == "true") ? "false" : "true";
       jQuery("a.subscribe_to_notes").attr("data-bp_is_subbed", subbedVal);
 
-      // Change button text
-      var txt = jQuery("a.subscribe_to_notes span.ui-button-text").html();
-      var newButtonText = txt.match("Unsubscribe") ? txt.replace("Unsubscribe", "Subscribe") : txt.replace("Subscribe", "Unsubscribe");
-      jQuery("a.subscribe_to_notes span.ui-button-text").html(newButtonText);
+      /*
+       * Update link text.
+       * Note that there are two links that allow users to subscribe/unsubscribe from notes emails. Given any ontology,
+       * one link is located on the top-level Notes tab, and the other link is located on the Notes sub-tab on the
+       * right-hand side of the Classes tab. Both links are handled by the subscriptions controller, and the text of
+       * both should be updated on success.
+       */
+      const matches = document.querySelectorAll('a.subscribe_to_notes');
+      matches.forEach(match => {
+        match.textContent = (subbedVal === 'true') ? 'Unsubscribe from notes emails' : 'Subscribe to notes emails';
+      });
     },
     error: function(data) {
       jQuery(".notes_subscribe_spinner").hide();

--- a/app/assets/javascripts/bp_notes.js
+++ b/app/assets/javascripts/bp_notes.js
@@ -341,13 +341,14 @@ function subscribeToNotes(button) {
   var ontologyId = jQuery(button).attr("data-bp_ontology_id");
   var isSubbed = jQuery(button).attr("data-bp_is_subbed");
   var userId = jQuery(button).attr("data-bp_user_id");
+  let encodedUserId = encodeURIComponent(userId);
 
   jQuery(".notes_sub_error").html("");
   jQuery(".notes_subscribe_spinner").show();
 
   jQuery.ajax({
     type: "POST",
-    url: "/subscriptions?user_id="+userId+"&ontology_id="+ontologyId+"&subbed="+isSubbed,
+    url: `/subscriptions?user_id=${encodedUserId}&ontology_id=${ontologyId}&subbed=${isSubbed}`,
     dataType: "json",
     success: function(data) {
       jQuery(".notes_subscribe_spinner").hide();

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,48 +1,38 @@
+# frozen_string_literal: true
+
 class SubscriptionsController < ApplicationController
-
   def create
-    # Try to get the user linked data instance
-    user_id = params[:user_id]
-    u = LinkedData::Client::Models::User.find(user_id)
-    raise Exception if u.nil?
-
-    # Try to get the ontology linked data instance
-    ontology_id = params[:ontology_id]
-    if ontology_id.start_with? 'http'
-      ont = LinkedData::Client::Models::Ontology.find(ontology_id)
-    else
-      ont = LinkedData::Client::Models::Ontology.find_by_acronym(ontology_id).first
-    end
-    raise Exception if ont.nil?
+    u = LinkedData::Client::Models::User.find(params[:user_id])
+    ont = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology_id]).first
 
     # Is this request to add or remove a subscription?
-    subscribed = params[:subbed]  # string (not boolean)
-    if subscribed.eql?("true")
+    subscribed = params[:subbed]
+    if subscribed.eql?('true')
       # Already subscribed, so this request must be a delete
       # Note that this routine removes ALL subscriptions for the ontology, regardless of type.
       # Previous way to delete subscription: error when u.update if more than 1 subscription in the subscription array:
-      #u.subscription.delete_if {|sub| sub[:ontology].split('/').last.eql?(ont.acronym) }
+      # u.subscription.delete_if {|sub| sub[:ontology].split('/').last.eql?(ont.acronym) }
       # So here we re-generate a new subscription Array (instead of directly updating it, which causes error)
       all_subs = []
       u.subscription.each do |subs|
         # Add all subscription to the array, but not the one to be deleted
         if !subs.ontology.split('/').last.eql?(ont.acronym)
-          all_subs.push({ontology: subs.ontology, notification_type: subs.notification_type})
+          all_subs.push({ ontology: subs.ontology, notification_type: subs.notification_type })
         end
       end
       u.subscription = all_subs
     else
       # Not subscribed yet, so this request must be for adding subscription
       # Old way:
-      #subscription = {ontology: ont.acronym, notification_type: "NOTES"} #NOTIFICATION_TYPES[:notes]}
-      #u.subscription.push(subscription)
+      # subscription = {ontology: ont.acronym, notification_type: "NOTES"} #NOTIFICATION_TYPES[:notes]}
+      # u.subscription.push(subscription)
       # This way was not working, updating subscription is failing when more than 1 subscription in the array
       # And we were updating with different types of object in the subscription array : OpenStruct and hash
       # So we are generating an array with only hash
-      all_subs = [{ontology: ont.acronym, notification_type: "NOTES"}] # the new subscription
+      all_subs = [{ ontology: ont.acronym, notification_type: 'NOTES' }] # the new subscription
       u.subscription.each do |subs|
         # add all existing subscriptions
-        all_subs.push({ontology: subs.ontology, notification_type: subs.notification_type})
+        all_subs.push({ ontology: subs.ontology, notification_type: subs.notification_type })
       end
       u.subscription = all_subs
     end
@@ -53,27 +43,25 @@ class SubscriptionsController < ApplicationController
       if response_success?(error_response)
         updated_sub = true
         session[:user].subscription = u.subscription
-        #session[:user] = u
+        # session[:user] = u
         # NOTES:
         # - Cannot update session[:user] as above.  The session user object is special because it only
         #   gets set when someone logs in and the user object returned when authenticating is the
         #   only one that will contain the api key for security reasons. So we actually need to use
         #   the update_from_params method, can’t just set the object to the user linked data instance.
         #
-        #session[:user].update_from_params(params[:user])
+        # session[:user].update_from_params(params[:user])
         # update_from_params first gets all attributes from the REST service for the object being updated,
         # then sets the values provided in the params hash where the param keys match setter names on the
         # object (in this case, for example, :subscription would set the @subscription value on the instance).
         # That’s all it does, no saving or anything.
       else
         updated_sub = false
-        #errors = response_errors(error_response)
       end
-    rescue
+    rescue StandardError
       updated_sub = false
     end
 
-    render :json => { :updated_sub => updated_sub, :user_subscriptions => u.subscription }
+    render json: { updated_sub: updated_sub, user_subscriptions: u.subscription }
   end
-
 end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -148,14 +148,14 @@ module NotesHelper
         ont = LinkedData::Client::Models::Ontology.find_by_acronym(ontology_id).first
       end
       subscribed = subscribed_to_ontology?(ont.acronym, user)  # application_helper
-      sub_text = subscribed ? "Unsubscribe" : "Subscribe"
+      sub_text = subscribed ? "Unsubscribe from" : "Subscribe to"
       params = "data-bp_ontology_id='#{ont.acronym}' data-bp_is_subbed='#{subscribed}' data-bp_user_id='#{user.id}'"
     rescue
       # pass, fallback init done above begin block to scope parameters beyond the begin/rescue block
     end
     spinner = '<span class="notes_subscribe_spinner" style="display: none;">' + image_tag("spinners/spinner_000000_16px.gif", style: "vertical-align: text-bottom;") + '</span>'
     error = "<span style='color: red;' class='notes_sub_error'></span>"
-    return "<a href='javascript:void(0);' class='subscribe_to_notes link_button' #{params}>#{sub_text} to notes emails</a> #{spinner} #{error}".html_safe
+    return "<a href='javascript:void(0);' class='subscribe_to_notes link_button' #{params}>#{sub_text} notes emails</a> #{spinner} #{error}".html_safe
   end
 
   def delete_button

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -132,10 +132,11 @@ module NotesHelper
 
   def subscribe_button(ontology_id)
     user = session[:user]
+
     if user.nil?
-      # subscribe button must redirect to login
-      return sanitize("<a href='/login?redirect=#{request.url}' style='font-size: .9em;' class='link_button subscribe_to_notes'>Subscribe to notes emails</a>")
+      return link_to('Subscribe to notes emails', login_index_path, class: 'link_button')
     end
+
     # Init subscribe button parameters.
     sub_text = "Subscribe"
     params = "data-bp_ontology_id='#{ontology_id}' data-bp_is_subbed='false' data-bp_user_id='#{user.id}'"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -76,11 +76,13 @@
       var ontologyId = jQuery(button).attr("data-bp_ontology_id");
       var isSubbed = jQuery(button).attr("data-bp_is_subbed");
       var userId = jQuery(button).attr("data-bp_user_id");
+      let encodedUserId = encodeURIComponent(userId);
+
       jQuery(".subscribe_error").html("");
       jQuery(".subscribe_spinner").show();
       jQuery.ajax({
         type: "POST",
-        url: "/subscriptions?user_id="+userId+"&ontology_id="+ontologyId+"&subbed="+isSubbed,
+        url: `/subscriptions?user_id=${encodedUserId}&ontology_id=${ontologyId}&subbed=${isSubbed}`,
         dataType: "json",
         success: function(data) {
           jQuery(".subscribe_spinner").hide();


### PR DESCRIPTION
- Fixes #298
- Fixes #300
- Fixes `Uncaught TypeError` that prevents link text toggle on notes emails subscribe / unsubscribe
- Refactors the `subscribed_to_ontology?` method do account for user objects with unloaded subscription attributes
- Fixes some RuboCop warnings