### PR TITLE
Fix misleading error message after custom ontology set save

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,18 +110,18 @@ class UsersController < ApplicationController
     custom_ontologies = params[:ontology] ? params[:ontology][:ontologyId] : []
     custom_ontologies.reject!(&:blank?)
     @user.update_from_params(customOntology: custom_ontologies)
-    error_response = @user.update
+    response = @user.update
 
-    if error_response
-      flash[:notice] = 'Error saving Custom Ontologies, please try again'
-    else
-      updated_user = LinkedData::Client::Models::User.get(@user.id)
+    if response.success?
+      updated_user = LinkedData::Client::Models::User.get(@user.id, include: 'customOntology')
       session[:user].update_from_params(customOntology: updated_user.customOntology)
       flash[:notice] = if updated_user.customOntology.empty?
                          'Custom Ontologies were cleared'
                        else
                          'Custom Ontologies were saved'
                        end
+    else
+      flash[:notice] = 'Error saving Custom Ontologies, please try again'
     end
     redirect_to user_path(@user.username)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -116,12 +116,12 @@ class UsersController < ApplicationController
       updated_user = LinkedData::Client::Models::User.get(@user.id, include: 'customOntology')
       session[:user].update_from_params(customOntology: updated_user.customOntology)
       flash[:notice] = if updated_user.customOntology.empty?
-                         'Custom Ontologies were cleared'
+                         'Custom ontology set successfully cleared'
                        else
-                         'Custom Ontologies were saved'
+                         'Custom ontology set successfully saved'
                        end
     else
-      flash[:error] = 'Error saving Custom Ontologies, please try again'
+      flash[:error] = 'Error saving custom ontology set. Please try again.'
     end
     redirect_to user_path(@user.username)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,8 +105,7 @@ class UsersController < ApplicationController
   end
 
   def custom_ontologies
-    @user = LinkedData::Client::Models::User.find(params[:id])
-    @user = LinkedData::Client::Models::User.find_by_username(params[:id]).first if @user.nil?
+    @user = LinkedData::Client::Models::User.get(params[:id])
 
     custom_ontologies = params[:ontology] ? params[:ontology][:ontologyId] : []
     custom_ontologies.reject!(&:blank?)
@@ -116,7 +115,7 @@ class UsersController < ApplicationController
     if error_response
       flash[:notice] = 'Error saving Custom Ontologies, please try again'
     else
-      updated_user = LinkedData::Client::Models::User.find(@user.id)
+      updated_user = LinkedData::Client::Models::User.get(@user.id)
       session[:user].update_from_params(customOntology: updated_user.customOntology)
       flash[:notice] = if updated_user.customOntology.empty?
                          'Custom Ontologies were cleared'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -121,7 +121,7 @@ class UsersController < ApplicationController
                          'Custom Ontologies were saved'
                        end
     else
-      flash[:notice] = 'Error saving Custom Ontologies, please try again'
+      flash[:error] = 'Error saving Custom Ontologies, please try again'
     end
     redirect_to user_path(@user.username)
   end

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -130,7 +130,7 @@
       - if @user_ontologies.present?
         %ul
           - @user_ontologies.each do |ont|
-            - ont = LinkedData::Client::Models::Ontology.get(ont)
+            - ont = LinkedData::Client::Models::Ontology.get(ont, include: 'name,acronym')
             %li
               #{ont.name} (#{ont.acronym})
       - else

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -121,14 +121,14 @@
     }
 
   %h4{class: 'pb-2 mt-5 mb-4 border-bottom'} Custom ontology set
-  #custom_ontologies.enable-lists
+  #custom_ontologies
     - if at_slice?
       = custom_ontology_set_slice_text
     - else
       = custom_ontology_set_intro_text
       = button_tag('Select ontologies', type: 'button', id: 'edit_custom_ontologies', class: 'btn btn-primary')
       - if @user_ontologies.present?
-        %ul
+        %ul{class: 'list-unstyled mt-3 mb-5'}
           - @user_ontologies.each do |ont|
             - ont = LinkedData::Client::Models::Ontology.get(ont, include: 'name,acronym')
             %li


### PR DESCRIPTION
This PR resolves an issue where a misleading error message was shown following the successful save of a custom ontology set (#330). Additional updates include:

* Replace deprecated `find` with `get` in `UsersController#custom_ontologies`
* Apply the correct flash message style for error notifications during custom ontology set save operations
* Improve the text content of flash notice and error messages when modifying custom ontology sets
* Tweak the list style for custom ontology set lists to improve appearance