### PR TITLE
Add option to test a specific set of ontologies

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,4 +40,6 @@ API_IMAGE_REPOSITORY=agroportal
 ## Image tag/version from which the ontoportal api will be built
 API_IMAGE_TAG=master
 
-
+## Tests
+# List of Ontologies to test in test/controllers/ontologies_controller_test.rb
+# ONTOLOGIES_TO_TEST="NCIT,GO,SNOMEDCT"

--- a/test/controllers/ontologies_controller_test.rb
+++ b/test/controllers/ontologies_controller_test.rb
@@ -3,9 +3,16 @@
 require 'test_helper'
 
 class OntologiesControllerTest < ActionDispatch::IntegrationTest
-  ONTOLOGIES = LinkedData::Client::Models::Ontology.all(include: 'acronym')
-  # ONTOLOGIES = LinkedData::Client::Models::Ontology.find_by_acronym('NCIT', include: 'acronym')
-  #
+  ONTOLOGIES = []
+  if ENV['ONTOLOGIES_TO_TEST'].nil?
+    ONTOLOGIES.concat(LinkedData::Client::Models::Ontology.all(include: 'acronym'))
+  else
+    ontologies_to_test = ENV['ONTOLOGIES_TO_TEST']&.split(',')&.map(&:strip)
+    ontologies_to_test.each do | ont |
+      ONTOLOGIES << LinkedData::Client::Models::Ontology.find(ont, include: 'acronym')
+    end
+  end
+
   # PAGES: schemes, collections are not yet implemented
   #PAGES = %w[summary classes properties notes mappings schemes collections widgets].freeze
   PAGES = %w[summary classes properties notes mappings widgets].freeze


### PR DESCRIPTION
Provide the ability to specify a list of ontologies to test instead of testing all ontologies. This is useful when testing APIs with a large number of ontologies.