### PR TITLE
Fix: Render 404 for non-existing ontologies and projects

### DIFF
--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -255,7 +255,7 @@ class OntologiesController < ApplicationController
 
     # Note: find_by_acronym includes ontology views
     @ontology = LinkedData::Client::Models::Ontology.find_by_acronym(params[:ontology], include: 'all').first
-    not_found if @ontology.nil?
+    not_found if @ontology&.errors && [401, 403, 404].include?(@ontology&.status)
 
     # Handle the case where an ontology is converted to summary only. 
     # See: https://github.com/ncbo/bioportal_web_ui/issues/133.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -18,6 +18,7 @@ class ProjectsController < ApplicationController
 
   def show
     @project = LinkedData::Client::Models::Project.get(params[:id])
+    not_found if @project&.errors && @project.status == 404
     @ontologies_used = []
     onts_used = @project.ontologyUsed
     onts_used.each do |ont_used|


### PR DESCRIPTION
Render 404 status for non-existing ontologies and projects.

Note: A 404 status is also returned when private ontologies are accessed without the required privileges. This behavior could be enhanced in the future to display a custom message.

Addresses: [ncbo/bioportal_web_ui#334](https://github.com/ncbo/bioportal_web_ui/issues/334)