### PR TITLE
Footer updates: free access notice and use of cookies link

### DIFF
--- a/app/assets/stylesheets/bootstrap_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_overrides.scss
@@ -12,7 +12,7 @@ main > .container-fluid {
 
 .footer {
   width: 100%;
-  height: 300px; /* Set the fixed height of the footer here */
+  height: 310px; /* Set the fixed height of the footer here */
   color: #757575;
   background-color: #ccc;
   color: #757575;

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -58,22 +58,31 @@
     %div.row.legal-text
       %div.col
         = t('.grant_html')
-    %div.row.pt-2.legal-text
+    %div.row.pt-1.legal-text
+      %div.col
+        = t('.free_access', site: "#{$SITE}")
+    %div.row.pt-1.legal-text
       %div.col
         = t('.copyright_html')
     %div.row.pt-2
       %div.col
         %ul.list-inline.nav
           %li.list-inline-item.nav-item
-            = link_to('CITE US', Rails.configuration.settings.links[:cite], class: 'nav-link p-0', target: '_blank')
+            = link_to('Cite Us', Rails.configuration.settings.links[:cite], class: 'nav-link p-0', target: '_blank')
           %li.list-inline-item
             %i.fas.fa-ellipsis-v{"aria-hidden" => "true"}
           %li.list-inline-item
-            = link_to('PRIVACY POLICY', Rails.configuration.settings.links[:privacy_policy],class: 'nav-link p-0',
+            = link_to('Privacy Policy', Rails.configuration.settings.links[:privacy_policy],class: 'nav-link p-0',
                       target: '_blank')
           %li.list-inline-item
             %i.fas.fa-ellipsis-v{"aria-hidden" => "true"}
           %li.list-inline-item
-            = link_to('TERMS', Rails.configuration.settings.links[:terms], class: 'nav-link p-0', target: '_blank')
+            = link_to('Terms of Use', Rails.configuration.settings.links[:terms], class: 'nav-link p-0',
+                      target: '_blank')
+          %li.list-inline-item
+            %i.fas.fa-ellipsis-v{"aria-hidden" => "true"}
+          %li.list-inline-item
+            = link_to('Use of Cookies', Rails.configuration.settings.links[:cookies], class: 'nav-link p-0',
+                      target: '_blank')
 
 = javascript_include_tag "application"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
   layouts:
     footer:
       copyright_html: Copyright &copy; 2005‑2024, The Board of Trustees of Leland Stanford Junior University. All rights reserved.
+      free_access: "%{site} is free and open to all users, with no login required."
       grant_html: >
         The <strong>National Center for Biomedical Ontology</strong> was founded as one of the National Centers for Biomedical 
         Computing, supported by the NHGRI, the NHLBI, and the NIH Common Fund under grant U54-HG004028.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,7 @@ shared:
   links:
     about: 'https://www.bioontology.org/about-us/'
     cite: 'https://www.bioontology.org/about-us/#cite-bioportal'
+    cookies: 'https://www.bioontology.org/terms/#use-of-cookies'
     facebook: 'https://www.facebook.com/National-Center-for-Biomedical-Ontology-127444774011153/'
     github: 'http://github.com/ncbo'
     help: 'https://www.bioontology.org/wiki/BioPortal_Help'


### PR DESCRIPTION
This pull request introduces modifications to the footer to align with requirements for an upcoming NAR proposal submission for a BioPortal paper.

- Adds a statement that BioPortal is free and open to all users
- Adjusts the footer height slightly to accommodate this new statement
- Adds a translation for the "free and open" statement to in the `en.yml` file to support internationalization
- Adds a new "Use of Cookies" link to the collection of footer links
- Updates `settings.yml` to store the physical URL for the section in BioPortal’s Terms of Use that describes the application’s use of cookies