### PR TITLE
Implement the TextDefinitionReplacement ontology change request type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.2)
+    logger (1.6.4)
     loofah (2.23.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)

--- a/app/assets/stylesheets/concepts.scss
+++ b/app/assets/stylesheets/concepts.scss
@@ -22,12 +22,12 @@
   white-space: nowrap;
 }
 
-div.synonym-change-request {
+div.change-request-buttons {
   display: flex;
   column-gap: 5px;
   justify-content: flex-end;
 }
 
-div.synonym-change-request button {
+div.change-request-buttons button {
   padding: 0px;
 }

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -29,8 +29,13 @@ class ChangeRequestsController < ApplicationController
   def create
     params[:curie] = generate_curie(params[:ont_acronym], params[:concept_id])
     params[:content] = KGCL::IssueContentGenerator.call(params)
-    @issue = IssueCreatorService.call(params)
-    flash.now.notice = helpers.change_request_success_message if @issue['id'].present?
+
+    result = IssueCreatorService.call(params)
+    if result[:success]
+      flash.now.notice = helpers.change_request_success_message(result[:issue])
+    else
+      flash.now.alert = "Change request failed: #{result[:error]}"
+    end
 
     # TODO: remove format.js from this block, and the create.js.erb file after the create_synonym and
     #   remove_synonym actions are converted from Rails UJS to Turbo Streams.

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -12,6 +12,11 @@ class ChangeRequestsController < ApplicationController
     respond_to :turbo_stream
   end
 
+  def edit_definition
+    @definition = params[:concept_definition]
+    respond_to :turbo_stream
+  end
+
   def create_synonym
     respond_to :js
   end

--- a/app/helpers/change_requests_helper.rb
+++ b/app/helpers/change_requests_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module ChangeRequestsHelper
-  def change_request_success_message
-    url = link_to 'details', @issue['url'], target: '_blank', class: 'alert-link'
-    "Your change request was successfully submitted! View the #{url} on GitHub.".html_safe
+  def change_request_success_message(issue)
+    url = link_to 'details', issue['url'], target: '_blank'
+    raw "Your change request was successfully submitted! View the #{url} on GitHub."
   end
 
   def change_request_alert_context

--- a/app/helpers/change_requests_helper.rb
+++ b/app/helpers/change_requests_helper.rb
@@ -17,7 +17,7 @@ module ChangeRequestsHelper
                                                  concept_definition: definition, ont_acronym: @ontology.acronym),
             role: 'button', class: 'btn btn-link', 'aria-label': 'Edit definition',
             data: { 'turbo': true, 'turbo-stream': 'true', 'turbo-frame': '_top' }) do
-      content_tag(:i, '', class: 'fas fa-user-edit fa-lg', aria: { hidden: 'true' })
+      content_tag(:i, '', class: 'fas fa-pen fa-lg', aria: { hidden: 'true' })
     end
   end
 

--- a/app/helpers/change_requests_helper.rb
+++ b/app/helpers/change_requests_helper.rb
@@ -10,6 +10,17 @@ module ChangeRequestsHelper
     flash.notice.present? ? 'alert-success' : 'alert-danger'
   end
 
+  def edit_definition_button(definition)
+    return unless change_requests_enabled?(@ontology.acronym)
+
+    link_to(change_requests_edit_definition_path(concept_id: @concept.id, concept_label: @concept.prefLabel,
+                                                 concept_definition: definition, ont_acronym: @ontology.acronym),
+            role: 'button', class: 'btn btn-link', 'aria-label': 'Edit definition',
+            data: { 'turbo': true, 'turbo-stream': 'true', 'turbo-frame': '_top' }) do
+      content_tag(:i, '', class: 'fas fa-user-edit fa-lg', aria: { hidden: 'true' })
+    end
+  end
+
   def add_synonym_button
     return unless change_requests_enabled?(@ontology.acronym)
 

--- a/app/javascript/controllers/change_requests_controller.js
+++ b/app/javascript/controllers/change_requests_controller.js
@@ -2,9 +2,27 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="change-requests"
 export default class extends Controller {
-  static targets = [ 'addProposalForm' ]
+  static targets = [ 'addProposalForm', 'editDefinitionForm' ]
+
+  /*
+   * TODO: code for hiding the various change request forms on cancel and submit needs to be refactored
+   */
+
+  connect() {
+    this.editDefinitionFormTarget.addEventListener('turbo:submit-end', this.hideForm.bind(this));
+  }
 
   clearProposalForm() {
     this.addProposalFormTarget.innerHTML = '';
+  }
+
+  clearEditDefinitionForm() {
+    this.editDefinitionFormTarget.innerHTML = '';
+  }
+
+  hideForm(event) {
+    if (event.detail.success) {
+      this.editDefinitionFormTarget.innerHTML = '';
+    }
   }
 }

--- a/app/javascript/controllers/change_requests_controller.js
+++ b/app/javascript/controllers/change_requests_controller.js
@@ -2,27 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="change-requests"
 export default class extends Controller {
-  static targets = [ 'addProposalForm', 'editDefinitionForm' ]
-
-  /*
-   * TODO: code for hiding the various change request forms on cancel and submit needs to be refactored
-   */
-
-  connect() {
-    this.editDefinitionFormTarget.addEventListener('turbo:submit-end', this.hideForm.bind(this));
-  }
+  static targets = [ 'proposalForm' ]
 
   clearProposalForm() {
-    this.addProposalFormTarget.innerHTML = '';
-  }
-
-  clearEditDefinitionForm() {
-    this.editDefinitionFormTarget.innerHTML = '';
+    this.proposalFormTarget.innerHTML = '';
   }
 
   hideForm(event) {
     if (event.detail.success) {
-      this.editDefinitionFormTarget.innerHTML = '';
+      this.clearProposalForm();
     }
   }
 }

--- a/app/lib/kgcl/issue_content_generator.rb
+++ b/app/lib/kgcl/issue_content_generator.rb
@@ -6,7 +6,8 @@ module KGCL
       KGCL::Operations::NEW_SYNONYM => KGCL::Renderers::NewSynonymContent,
       KGCL::Operations::NODE_OBSOLETION => KGCL::Renderers::NodeObsoletionContent,
       KGCL::Operations::NODE_RENAME => KGCL::Renderers::NodeRenameContent,
-      KGCL::Operations::REMOVE_SYNONYM => KGCL::Renderers::RemoveSynonymContent
+      KGCL::Operations::REMOVE_SYNONYM => KGCL::Renderers::RemoveSynonymContent,
+      KGCL::Operations::TEXT_DEFINITION_REPLACEMENT => KGCL::Renderers::EditDefinitionContent
     }.freeze
 
     def self.call(params)

--- a/app/lib/kgcl/operations.rb
+++ b/app/lib/kgcl/operations.rb
@@ -6,5 +6,6 @@ module KGCL
     NODE_OBSOLETION = 'NodeObsoletionContent'
     NODE_RENAME = 'NodeRenameContent'
     REMOVE_SYNONYM = 'RemoveSynonymContent'
+    TEXT_DEFINITION_REPLACEMENT = 'TextDefinitionReplacementContent'
   end
 end

--- a/app/lib/kgcl/renderers/edit_definition_content.rb
+++ b/app/lib/kgcl/renderers/edit_definition_content.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module KGCL
+  module Renderers
+    # Generate GitHub issue content for a text definition replacement change request.
+    #
+    # The change request is described using the Knowledge Graph Change Language grammar, e.g.:
+    #
+    #   change definition of GO:0008150 from 'lorem ipsum' to 'lorem ipsum dolor sit amet'
+    #
+    # @see https://incatools.github.io/kgcl/TextDefinitionReplacement
+    #
+    class EditDefinitionContent < IssueContent
+      def comment
+        @params[:edit_definition][:comment]
+      end
+
+      def get_binding
+        binding
+      end
+
+      def new_definition
+        @params[:edit_definition][:definition]
+      end
+
+      def old_definition
+        @params[:old_definition]
+      end
+
+      def title_template
+        'edit_definition_title.erb'
+      end
+
+      def body_template
+        'edit_definition_body.erb'
+      end
+    end
+  end
+end

--- a/app/lib/kgcl/templates/edit_definition_body.erb
+++ b/app/lib/kgcl/templates/edit_definition_body.erb
@@ -1,0 +1,8 @@
+## Hey ontobot! apply:
+
+* change definition of <%= curie %> from '<%= old_definition %>' to '<%= new_definition %>'
+
+---
+
+<% footer_template = File.read("#{Rails.root}/app/lib/kgcl/templates/footer.erb") %>
+<%= ERB.new(footer_template, trim_mode: '<>', eoutvar: 'footer').result(binding) %>

--- a/app/lib/kgcl/templates/edit_definition_title.erb
+++ b/app/lib/kgcl/templates/edit_definition_title.erb
@@ -1,0 +1,1 @@
+Proposal: modify the definition of '<%= concept_label %>'

--- a/app/views/change_requests/_edit_definition.html.haml
+++ b/app/views/change_requests/_edit_definition.html.haml
@@ -1,0 +1,23 @@
+= form_with(scope: :edit_definition, url: change_requests_path, data: {turbo: true, turbo_frame: 'top'},
+            class: 'my-4') do |f|
+  = hidden_field_tag 'concept_id', @concept_id
+  = hidden_field_tag 'concept_label', @concept_label
+  = hidden_field_tag 'github_id', @user.githubId
+  = hidden_field_tag 'old_definition', @definition
+  = hidden_field_tag 'ont_acronym', @ont_acronym
+  = hidden_field_tag 'orcid_id', @user.orcidId
+  = hidden_field_tag 'username', @user.username
+  = hidden_field_tag 'operation', KGCL::Operations::TEXT_DEFINITION_REPLACEMENT
+  %div.mb-3
+    = f.label :definition, "Proposal: modify the definition of '#{@concept_label}'", class: 'form-label'
+    = f.text_area(:definition, class: 'form-control', value: sanitize(@definition),
+                  'aria-describedby': 'editDefinitionHelpBlock')
+    = tag.div 'Enter the desired replacement text', class: 'form-text', id: 'editDefinitionHelpBlock'
+  %div.mb-3
+    = f.label :comment, 'Comment', class: 'form-label'
+    = f.text_area :comment, class: 'form-control', 'aria-describedby': 'editDefinitionCommentHelpBlock'
+    = tag.div('Optionally enter a comment giving a reason for the modification', class: 'form-text',
+              id: 'editDefinitionCommentHelpBlock')
+  = submit_tag 'Submit', id: 'edit_definition_button', class: 'btn btn-primary btn-sm'
+  = tag.button('Cancel', type: 'button',
+               'data-action': 'click->change-requests#clearEditDefinitionForm', class: 'btn btn-primary btn-sm')

--- a/app/views/change_requests/_edit_definition.html.haml
+++ b/app/views/change_requests/_edit_definition.html.haml
@@ -10,15 +10,16 @@
   = hidden_field_tag 'username', @user.username
   = hidden_field_tag 'operation', KGCL::Operations::TEXT_DEFINITION_REPLACEMENT
   %div.mb-3
-    = f.label :definition, "Proposal: modify the definition of '#{@concept_label}'", class: 'form-label'
+    = f.label :definition, "Proposal: modify the definition of '#{@concept_label}'", class: 'form-label fs-6'
     = f.text_area(:definition, class: 'form-control', value: sanitize(@definition),
                   'aria-describedby': 'editDefinitionHelpBlock')
-    = tag.div 'Enter the desired replacement text', class: 'form-text', id: 'editDefinitionHelpBlock'
+    = tag.div('Enter the desired replacement text', class: 'form-text', style: 'font-size: 1em',
+              id: 'editDefinitionHelpBlock')
   %div.mb-3
-    = f.label :comment, 'Comment', class: 'form-label'
+    = f.label :comment, 'Comment', class: 'form-label fs-6'
     = f.text_area :comment, class: 'form-control', 'aria-describedby': 'editDefinitionCommentHelpBlock'
     = tag.div('Optionally enter a comment giving a reason for the modification', class: 'form-text',
-              id: 'editDefinitionCommentHelpBlock')
+              style: 'font-size: 1em', id: 'editDefinitionCommentHelpBlock')
   = submit_tag 'Submit', id: 'edit_definition_button', class: 'btn btn-primary btn-sm'
   = tag.button('Cancel', type: 'button',
                'data-action': 'click->change-requests#clearProposalForm', class: 'btn btn-primary btn-sm')

--- a/app/views/change_requests/_edit_definition.html.haml
+++ b/app/views/change_requests/_edit_definition.html.haml
@@ -1,4 +1,5 @@
-= form_with(scope: :edit_definition, url: change_requests_path, data: {turbo: true, turbo_frame: 'top'},
+= form_with(scope: :edit_definition, url: change_requests_path,
+            data: {turbo: true, turbo_frame: 'top', action: 'turbo:submit-end->change-requests#hideForm'},
             class: 'my-4') do |f|
   = hidden_field_tag 'concept_id', @concept_id
   = hidden_field_tag 'concept_label', @concept_label
@@ -20,4 +21,4 @@
               id: 'editDefinitionCommentHelpBlock')
   = submit_tag 'Submit', id: 'edit_definition_button', class: 'btn btn-primary btn-sm'
   = tag.button('Cancel', type: 'button',
-               'data-action': 'click->change-requests#clearEditDefinitionForm', class: 'btn btn-primary btn-sm')
+               'data-action': 'click->change-requests#clearProposalForm', class: 'btn btn-primary btn-sm')

--- a/app/views/change_requests/_node_obsoletion.html.haml
+++ b/app/views/change_requests/_node_obsoletion.html.haml
@@ -1,4 +1,6 @@
-= form_with scope: :node_obsoletion, url: change_requests_path, data: {turbo: true, turbo_frame: '_top'}, class: 'mb-5' do |f|
+= form_with(scope: :node_obsoletion, url: change_requests_path,
+            data: {turbo: true, turbo_frame: '_top', action: 'turbo:submit-end->change-requests#hideForm'},
+            class: 'mb-5') do |f|
   = hidden_field_tag 'concept_id', @concept_id
   = hidden_field_tag 'concept_label', @concept_label
   = hidden_field_tag 'github_id', @user.githubId

--- a/app/views/change_requests/_node_rename.html.haml
+++ b/app/views/change_requests/_node_rename.html.haml
@@ -1,5 +1,7 @@
 = tag.p("Proposal: rename '#{@concept_label}'", class: 'lead')
-= form_with scope: :node_rename, url: change_requests_path, data: {turbo: true}, class: 'mb-5' do |f|
+= form_with(scope: :node_rename, url: change_requests_path,
+            data: {turbo: true, turbo_frame: '_top', action: 'turbo:submit-end->change-requests#hideForm'},
+            class: 'mb-5') do |f|
   = hidden_field_tag 'concept_id', @concept_id
   = hidden_field_tag 'concept_label', @concept_label
   = hidden_field_tag 'github_id', @user.githubId

--- a/app/views/change_requests/_notice.html.haml
+++ b/app/views/change_requests/_notice.html.haml
@@ -1,4 +1,3 @@
-- if notice.present?
-  %div{class: "alert #{change_request_alert_context} alert-dismissible fade show", role: 'alert'}
-    = notice
-    %button{type: 'button', class: 'btn-close', 'data-bs-dismiss': 'alert', 'aria-label': 'Close'}
+%div{class: "alert #{change_request_alert_context} alert-dismissible fade show", role: 'alert'}
+  = notice.present? ? notice : alert
+  %button{type: 'button', class: 'btn-close', 'data-bs-dismiss': 'alert', 'aria-label': 'Close'}

--- a/app/views/change_requests/create.js.erb
+++ b/app/views/change_requests/create.js.erb
@@ -1,2 +1,1 @@
 document.getElementById('change-request-notice').innerHTML = '<%= j render partial: "notice" %>'
-document.getElementById('addProposalFormDiv').innerHTML = '';

--- a/app/views/change_requests/create.turbo_stream.haml
+++ b/app/views/change_requests/create.turbo_stream.haml
@@ -1,4 +1,2 @@
 = turbo_stream.update 'change-request-notice' do
   = render partial: 'notice'
-
-= turbo_stream.update 'addProposalFormDiv'

--- a/app/views/change_requests/edit_definition.turbo_stream.haml
+++ b/app/views/change_requests/edit_definition.turbo_stream.haml
@@ -1,0 +1,2 @@
+= turbo_stream.update 'editDefinitionFormDiv' do
+  = render partial: 'edit_definition'

--- a/app/views/concepts/_details.html.haml
+++ b/app/views/concepts/_details.html.haml
@@ -20,7 +20,7 @@
                                                      ont_acronym: @ontology.acronym),
                     class: 'dropdown-item', 'data-turbo': 'true', 'data-turbo-stream': 'true','data-turbo-frame': '_top')
     %div{'data-controller': 'change-requests'}
-      %div{id: 'addProposalFormDiv', 'data-change-requests-target': 'addProposalForm'}
+      %div{id: 'addProposalFormDiv', 'data-change-requests-target': 'proposalForm'}
 
   %table.minimal.concept_details{cellpadding: "0", cellspacing: "0", width: "100%"}
     %tr
@@ -112,7 +112,7 @@
             - if key.eql?('definition')
               %div= sanitize(values.first)
               %div{'data-controller': 'change-requests'}
-                %div{id: 'editDefinitionFormDiv', 'data-change-requests-target': 'editDefinitionForm'}
+                %div{id: 'editDefinitionFormDiv', 'data-change-requests-target': 'proposalForm'}
             - else
               -# Note: get_link_for_cls_ajax is in application_helper.rb, it calls auto_link when necessary.
               - ajax_links = values.map {|v| get_link_for_cls_ajax(v, @ontology.acronym, '_blank') }

--- a/app/views/concepts/_details.html.haml
+++ b/app/views/concepts/_details.html.haml
@@ -38,7 +38,7 @@
         - for synonym in @concept.synonym
           %p= synonym
       %td 
-        %div.synonym-change-request
+        %div.change-request-buttons
           = add_synonym_button
           = remove_synonym_button
     - unless @concept.definition.nil? || @concept.definition.empty?
@@ -109,15 +109,19 @@
         %tr
           %td= "#{remove_owl_notation(key)}"
           %td
-
-            -# NCBO-648 Note: a property with complex values might return an array of nils from the REST-API client code.
-            -# If we use values.compact or values.any? we may miss exceptions on data that should be handled better.
-
-            -# Note: get_link_for_cls_ajax is in application_helper.rb, it calls auto_link when necessary.
-            - ajax_links = values.map {|v| get_link_for_cls_ajax(v, @ontology.acronym, '_blank') }
-            = "<p>#{sanitize(ajax_links.join('</p><p>'))}</p>".html_safe
-            -# auto_link("<p>#{sanitize(values.join("<br/>")).split("||%||").join("<\/p><p>").gsub("%ONT%", @ontology.acronym)}</p>", :all, :target => "_blank")
+            - if key.eql?('definition')
+              %div= sanitize(values.first)
+              %div{'data-controller': 'change-requests'}
+                %div{id: 'editDefinitionFormDiv', 'data-change-requests-target': 'editDefinitionForm'}
+            - else
+              -# Note: get_link_for_cls_ajax is in application_helper.rb, it calls auto_link when necessary.
+              - ajax_links = values.map {|v| get_link_for_cls_ajax(v, @ontology.acronym, '_blank') }
+              = "<p>#{sanitize(ajax_links.join('</p><p>'))}</p>".html_safe
+              -# auto_link("<p>#{sanitize(values.join("<br/>")).split("||%||").join("<\/p><p>").gsub("%ONT%", @ontology.acronym)}</p>", :all, :target => "_blank")
           %td
+            - if key.eql?('definition')
+              %div.change-request-buttons
+                = edit_definition_button(values.first)
 
     -# BOTTOM set of properties
     - for key in bottom_set

--- a/config/change_request.yml
+++ b/config/change_request.yml
@@ -10,7 +10,7 @@ development:
     GO:
       repository: 'hrshdhgd/go-ontology'
     MONDO:
-      repository: 'hrshdhgd/mondo'
+      repository: 'caufieldjh/mondo'
     UBERON:
       repository: 'hrshdhgd/uberon'
 
@@ -21,7 +21,7 @@ staging:
     GO:
       repository: 'hrshdhgd/go-ontology'
     MONDO:
-      repository: 'hrshdhgd/mondo'
+      repository: 'caufieldjh/mondo'
     UBERON:
       repository: 'hrshdhgd/uberon'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
 
   # Ontology change requests
   get 'change_requests/create_synonym'
+  get 'change_requests/edit_definition'
   get 'change_requests/node_obsoletion'
   get 'change_requests/node_rename'
   get 'change_requests/remove_synonym'


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the change request process. It adds support for the [TextDefinitionReplacement](https://incatools.github.io/kgcl/TextDefinitionReplacement/) change request type, enabling users to request modifications to the definitions of ontology classes.

Additionally, it improves error handling by addressing cases where users provide an invalid GitHub repository name or attempt to use a repository with the issue tracker disabled.

The code responsible for hiding change request forms on Cancel and Submit actions has been refactored to be more generic and reusable, ensuring consistency across all change request forms, regardless of type.

Changes to the `concepts/_details` partial were intentionally kept minimal, with the knowledge that this area of the application is undergoing a redesign.

Resolves #381