### PR TITLE
Account settings page refactors and navigation cleanup

### DIFF
--- a/app/assets/stylesheets/account.scss
+++ b/app/assets/stylesheets/account.scss
@@ -51,3 +51,9 @@
     text-decoration: underline;
   }
 }
+
+.administered-objects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 7px;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -95,31 +95,6 @@ class HomeController < ApplicationController
     render json: bp_config_json
   end
 
-  def account
-    @title = 'Account Information'
-    if session[:user].nil?
-      redirect_to controller: 'login', action: 'index', redirect: '/account'
-      return
-    end
-
-    @user = LinkedData::Client::Models::User.get(session[:user].id, include: 'all')
-
-    @user_ontologies = @user.customOntology
-    @user_ontologies ||= []
-
-    @admin_ontologies = LinkedData::Client::Models::Ontology.where(include_views: true) do |o|
-      o.administeredBy.include? @user.id
-    end
-    @admin_ontologies.sort! { |a, b| a.name.downcase <=> b.name.downcase }
-
-    @user_projects = LinkedData::Client::Models::Project.where do |p|
-      p.creator.include? @user.id
-    end
-    @user_projects.sort! { |a, b| a.name.downcase <=> b.name.downcase }
-
-    render 'users/show'
-  end
-
   def feedback_complete; end
 
   def validate_ontology_file_show; end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -108,9 +108,7 @@ class LoginController < ApplicationController
     return unless user
 
     session[:user] = user
-    custom_ontologies_text = session[:user].customOntology && !session[:user].customOntology.empty? ? "The display is now based on your <a href='/account#custom_ontology_set'>Custom Ontology Set</a>." : ""
-    notice = "Welcome <b>" + user.username.to_s + "</b>! " + custom_ontologies_text
-    flash[:success] = notice.html_safe
+    flash[:success] = helpers.welcome_message(user)
   end
 
   def validate(params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,14 +17,9 @@ class UsersController < ApplicationController
 
   def show
     @user = LinkedData::Client::Models::User.get(params[:id], include: 'all')
-    @all_ontologies = LinkedData::Client::Models::Ontology.all(ignore_custom_ontologies: true)
     @user_ontologies = @user.customOntology
-
-    # Copied from home controller, account action
-    @admin_ontologies = LinkedData::Client::Models::Ontology.where(include_views: true) do |o|
-      o.administeredBy.include? @user.id
-    end
-    @admin_ontologies.sort! { |a, b| a.name.downcase <=> b.name.downcase }
+    @all_ontologies = LinkedData::Client::Models::Ontology.all(ignore_custom_ontologies: true, include_views: true)
+    @admin_ontologies = @all_ontologies.select { |o| o.administeredBy.include? @user.id }
 
     @user_projects = LinkedData::Client::Models::Project.where do |p|
       p.creator.include? @user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,12 +19,10 @@ class UsersController < ApplicationController
     @user = LinkedData::Client::Models::User.get(params[:id], include: 'all')
     @user_ontologies = @user.customOntology
     @all_ontologies = LinkedData::Client::Models::Ontology.all(ignore_custom_ontologies: true, include_views: true)
-    @admin_ontologies = @all_ontologies.select { |o| o.administeredBy.include? @user.id }
-
-    @user_projects = LinkedData::Client::Models::Project.where do |p|
-      p.creator.include? @user.id
-    end
-    @user_projects.sort! { |a, b| a.name.downcase <=> b.name.downcase }
+    @admin_ontologies = @all_ontologies.filter { |o| o.administeredBy.include? @user.id }
+                                       .sort_by { |o| o.name.downcase }
+    @user_projects = LinkedData::Client::Models::Project.where { |p| p.creator.include? @user.id }
+                                                        .sort_by { |p| p.name.downcase }
   end
 
   def new

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SessionsHelper
+  def welcome_message(user)
+    tag.div do
+      concat('Welcome ')
+      concat(tag.span(user.username, class: 'fw-bold'))
+      concat('!')
+
+      if user.customOntology.present?
+        concat(' The display is now based on your ')
+        concat(link_to('Custom Ontology Set', user_path(user.username)))
+        concat('.')
+      end
+    end
+  end
+end

--- a/app/views/layouts/_topnav.html.haml
+++ b/app/views/layouts/_topnav.html.haml
@@ -32,7 +32,7 @@
               = session[:user].username
             %ul.dropdown-menu.dropdown-menu-end
               %li
-                = link_to("Account settings", "/account", class: "dropdown-item")
+                = link_to("Account settings", user_path(session[:user].username), class: "dropdown-item")
               - unless session[:ontologies].nil?
                 %li
                   %hr.dropdown-divider

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -61,19 +61,17 @@
   - unless @user_projects.blank?
     %h4{class: 'pb-2 mt-5 mb-4 border-bottom'} Projects
     = tag.p("Projects you created in #{$SITE}", class: 'text-muted')
-    %ul.list-unstyled
+    %div{class: 'administered-objects'}
       - @user_projects.each do |p|
-        %li
-          = link_to(p.name, project_path(p.acronym))
+        = render ChipButtonComponent.new(url: project_path(p.acronym), text: p.name, type: 'clickable')
 
   -# Ontologies this user administers
   - unless @admin_ontologies.blank?
     %h4{class: 'pb-2 mt-5 mb-4 border-bottom'} Ontologies
     = tag.p("Ontologies you have administrative access to in #{$SITE}", class: 'text-muted')
-    %ul.list-unstyled
+    %div{class: 'administered-objects'}
       - @admin_ontologies.each do |ont|
-        %li
-          = link_to(ont.name, ontology_path(ont.acronym))
+        = render ChipButtonComponent.new(url: ontology_path(ont.acronym), text: ont.name, type: 'clickable')
 
   :javascript
     jQuery(document).ready(function(){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,6 @@ Rails.application.routes.draw do
 
   # Top-level pages
   match '/feedback', to: 'home#feedback', via: [:get, :post]
-  get '/account' => 'home#account'
   get '/help' => 'home#help'
   get '/site_config' => 'home#site_config'
   get '/validate_ontology_file' => 'home#validate_ontology_file_show'


### PR DESCRIPTION
- Removed the `home#account` route in favor of consistently using `users#show` throughout the codebase for navigating to the account settings page
- Refactored `UsersController#show` to reduce REST calls for fetching ontologies from two to one
- Used `sort_by` instead of `sort!` in `UsersController#show` for better performance
- Introduced `SessionsHelper#welcome_message` to compose the welcome message upon login, allowing for cleaner code in `LoginController#login`
- Updated the Projects and Ontologies sections on the account settings page to use a CSS Flexbox layout, improving readability for admin users managing many projects/ontologies
- Replaced plain anchor links with chip button components for project and ontology items