### PR TITLE
Resolves the issue with displaying ontologies with no submissions (#430)

### DIFF
--- a/app/components/submission_metadata_component/submission_metadata_component.html.haml
+++ b/app/components/submission_metadata_component/submission_metadata_component.html.haml
@@ -1,9 +1,10 @@
-= render TableComponent.new(id: 'submission_metadata_table',small_text: true, custom_class: 'table table-sm', stripped: false) do |t|
-  - @metadata_list.each do |metadata, label|
-    - next if Array(@submission.send(metadata)).empty?
-    - t.row do |r|
-      - r.td(width: '200px', style: 'text-wrap: wrap') do
-        = attr_label(metadata.to_s, attr_metadata: attr_metadata(metadata.to_s), show_tooltip: false)
-      - r.td do
-        .d-flex.flex-wrap.flex-column
-          = display_attributes(metadata)
+- unless @submission.nil?
+  = render TableComponent.new(id: 'submission_metadata_table',small_text: true, custom_class: 'table table-sm', stripped: false) do |t|
+    - @metadata_list.each do |metadata, label|
+      - next if Array(@submission.send(metadata)).empty?
+      - t.row do |r|
+        - r.td(width: '200px', style: 'text-wrap: wrap') do
+          = attr_label(metadata.to_s, attr_metadata: attr_metadata(metadata.to_s), show_tooltip: false)
+        - r.td do
+          .d-flex.flex-wrap.flex-column
+            = display_attributes(metadata)

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -97,7 +97,7 @@ module OntologiesHelper
   end
 
   def download_button
-    return unless (@ontology.summaryOnly || @ont_restricted || @submissions.empty?)
+    return if (@ontology.summaryOnly || @ont_restricted || @submissions.empty?)
 
     down_link = @submissions.first.id + "/download?apikey=#{get_apikey}"
     render RoundedButtonComponent.new(link: down_link, icon: 'summary/download.svg',


### PR DESCRIPTION
Resolves https://github.com/ncbo/bioportal_web_ui/issues/430. There was a reference to the @submission object without a check for its validity. There was also a bug in the method that displays the "Download" button.