### PR TITLE
Add Capistrano Task to Announce Deployments in New Relic

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -25,5 +25,8 @@ install_plugin Capistrano::SCM::Git
 require 'capistrano/rails'
 require 'capistrano/locally'
 require 'capistrano/yarn'
+
+# announce deployments in NewRelic
+require 'new_relic/recipes'
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }

--- a/Capfile
+++ b/Capfile
@@ -23,10 +23,11 @@ install_plugin Capistrano::SCM::Git
 #require 'capistrano/rails/assets'
 #require 'capistrano/rails/migrations'
 require 'capistrano/rails'
+# locally is needed for the appliance deployments
 require 'capistrano/locally'
 require 'capistrano/yarn'
 
 # announce deployments in NewRelic
 require 'new_relic/recipes'
-# Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
-Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }
+# Load custom tasks from `lib/capistrano/tasks` if you have any defined
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r } # W

--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,6 @@ gem 'ffi'
 gem 'net-ftp', require: false
 gem 'net-http'
 
-
 # Multi-Provider Authentication
 gem 'omniauth'
 gem 'omniauth-rails_csrf_protection'
@@ -131,7 +130,7 @@ gem 'omniauth-rails_csrf_protection'
 # gem 'omniauth-keycloak'
 # gem 'omniauth-orcid'
 
-group :staging, :production, :appliance do
+group :staging, :production do
   # Application performance monitoring
   gem 'newrelic_rpm'
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -59,6 +59,9 @@ set :keep_assets, 3
 set :rbenv_type, :system
 set :rbenv_ruby, File.read('.ruby-version').strip
 
+# announce deployments in newrelic
+set :newrelic_enabled, false
+
 desc "Check if agent forwarding is working"
 task :forwarding do
   on roles(:all) do |h|
@@ -106,6 +109,10 @@ namespace :deploy do
 
   after :updating, :get_config
   after :publishing, :restart
+
+  if fetch(:newrelic_enabled, true)
+    after :restart, 'newrelic:notice_deployment'
+  end
 
   after :restart, :clear_cache do
     on roles(:app), in: :groups, limit: 3, wait: 10 do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -60,7 +60,7 @@ set :rbenv_type, :system
 set :rbenv_ruby, File.read('.ruby-version').strip
 
 # announce deployments in newrelic
-set :newrelic_enabled, false
+set :newrelic_notice_enabled, false
 
 desc "Check if agent forwarding is working"
 task :forwarding do
@@ -82,24 +82,6 @@ namespace :deploy do
     end
   end
 
-  desc 'Incorporate the bioportal_conf private repository content'
-  # Get cofiguration from repo if PRIVATE_CONFIG_REPO env var is set
-  # or get config from local directory if LOCAL_CONFIG_PATH env var is set
-  task :get_config do
-    if defined?(PRIVATE_CONFIG_REPO)
-      TMP_CONFIG_PATH = "/tmp/#{SecureRandom.hex(15)}".freeze
-      on roles(:app) do
-        execute "git clone -q #{PRIVATE_CONFIG_REPO} #{TMP_CONFIG_PATH}"
-        execute "rsync -a #{TMP_CONFIG_PATH}/#{fetch(:application)}/ #{release_path}/"
-        execute "rm -rf #{TMP_CONFIG_PATH}"
-      end
-    elsif defined?(LOCAL_CONFIG_PATH)
-      on roles(:app) do
-        execute "rsync -a #{LOCAL_CONFIG_PATH}/#{fetch(:application)}/ #{release_path}/"
-      end
-    end
-  end
-
   desc 'Restart application'
   task :restart do
     on roles(:app), in: :sequence, wait: 5 do
@@ -107,12 +89,10 @@ namespace :deploy do
     end
   end
 
-  after :updating, :get_config
+  after :updating, 'config:sync'
   after :publishing, :restart
 
-  if fetch(:newrelic_enabled, true)
-    after :restart, 'newrelic:notice_deployment'
-  end
+  after :restart, 'newrelic:report_deployment'
 
   after :restart, :clear_cache do
     on roles(:app), in: :groups, limit: 3, wait: 10 do

--- a/config/deploy/appliance.rb
+++ b/config/deploy/appliance.rb
@@ -45,8 +45,5 @@ set :branch, "#{BRANCH}"
 # install gems into a common direcotry shared across ui, api and ncbo_cron to reduce disk usage
 set :bundle_path, '/opt/ontoportal/.bundle'
 
-#private git repo for configuraiton
-#PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'git@github.com:your_org/private-config-repo.git'
-
-#location of configuration files
-LOCAL_CONFIG_PATH = ENV.include?('LOCAL_CONFIG_PATH') ? ENV['LOCAL_CONFIG_PATH'] : '/opt/ontoportal/virtual_appliance/appliance_config'
+# location of configuration files
+set :local_config_path, ENV['LOCAL_CONFIG_PATH'] || '/opt/ontoportal/virtual_appliance/appliance_config'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -44,6 +44,7 @@ set :ssh_options, {
   # use ssh proxy if UI servers are on a private network
   proxy: Net::SSH::Proxy::Command.new('ssh deployer@sshproxy.ontoportal.org -W %h:%p')
 }
-
+# enable production deploymnet announcements in NewRelic
+set :newrelic_notice_enabled, true
 #private git repo for configuraiton
-PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'git@github.com:author/private_config_repo.git'
+set :private_config_repo, ENV['PRIVATE_CONFIG_REPO'] || 'git@github.com:your_org/your_private_config_repo.git'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -46,4 +46,4 @@ set :ssh_options, {
 }
 
 #private git repo for configuraiton
-PRIVATE_CONFIG_REPO = ENV.include?('PRIVATE_CONFIG_REPO') ? ENV['PRIVATE_CONFIG_REPO'] : 'git@github.com:author/private_config_repo.git'
+set :private_config_repo, ENV['PRIVATE_CONFIG_REPO'] || 'git@github.com:your_org/your_private_config_repo.git'

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -10,18 +10,15 @@
 # https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
 
 common: &default_settings
-  # Required license key associated with your New Relic account.
-  license_key: <%= Rails.application.credentials[:newrelic][:license_key] %>
 
-  # Your application name. Renaming here affects where data displays in New
-  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
-  app_name: <%= Rails.application.credentials[:newrelic][:app_name] %>
+  license_key: <%= ENV['NEW_RELIC_LICENSE_KEY'] %>
+
 
   distributed_tracing:
     enabled: true
 
   # To disable the agent regardless of other settings, uncomment the following:
-  # agent_enabled: false
+  agent_enabled: false
 
   # Logging level for log/newrelic_agent.log
   log_level: info
@@ -44,16 +41,24 @@ common: &default_settings
       # This should not be used when forwarding is enabled.
       enabled: false
 
+
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
 # If your application has other named environments, configure them here.
-appliance:
+development:
   <<: *default_settings
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] %>
+
+test:
+  agent_enabled: false
+
+appliance:
+  agent_enabled: false
 
 production:
   <<: *default_settings
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] %>
 
 staging:
   <<: *default_settings
-  app_name: <%= Rails.application.credentials[:newrelic][:app_name] %>
-  license_key: <%= Rails.application.credentials[:newrelic][:license_key] %>
+  app_name: <%= ENV["NEW_RELIC_APP_NAME"] %> (Staging)

--- a/lib/capistrano/tasks/config.rake
+++ b/lib/capistrano/tasks/config.rake
@@ -1,0 +1,25 @@
+namespace :config do
+  desc 'Sync configuration files from private repo or local path into the release'
+  task :sync do
+    if fetch(:private_config_repo, nil)
+      tmp_path = "/tmp/#{SecureRandom.hex(15)}"
+      on roles(:app) do
+        info "Fetching configuration from private repo"  # Do NOT log the URL
+        execute "git clone -q #{fetch(:private_config_repo)} #{tmp_path}"
+        execute "rsync -a #{tmp_path}/#{fetch(:application)}/ #{release_path}/"
+        execute "rm -rf #{tmp_path}"
+      end
+
+    elsif ENV['LOCAL_CONFIG_PATH']
+      on roles(:app) do
+        info "Fetching configuration from local path"
+        execute "rsync -a #{ENV['LOCAL_CONFIG_PATH']}/#{fetch(:application)}/ #{release_path}/"
+      end
+
+    else
+      on roles(:app) do
+        warn "No PRIVATE_CONFIG_REPO or LOCAL_CONFIG_PATH provided. Skipping configuration injection."
+      end
+    end
+  end
+end

--- a/lib/capistrano/tasks/config.rake
+++ b/lib/capistrano/tasks/config.rake
@@ -10,15 +10,26 @@ namespace :config do
         execute "rm -rf #{tmp_path}"
       end
 
-    elsif ENV['LOCAL_CONFIG_PATH']
+    elsif fetch(:local_config_path, nil)
       on roles(:app) do
         info "Fetching configuration from local path"
-        execute "rsync -a #{ENV['LOCAL_CONFIG_PATH']}/#{fetch(:application)}/ #{release_path}/"
+        execute "rsync -a #{fetch(:local_config_path)}/#{fetch(:application)}/ #{release_path}/"
       end
 
     else
       on roles(:app) do
-        warn "No PRIVATE_CONFIG_REPO or LOCAL_CONFIG_PATH provided. Skipping configuration injection."
+        warn <<~MSG
+          Skipping configuration injection: no configuration source defined.
+          To fix this, set one of the following:
+
+          - Capistrano variable :private_config_repo (e.g. in stage file or via -s)
+          - Capistrano variable :local_config_path (or set LOCAL_CONFIG_PATH env var)
+
+          Example usage:
+            CONFIG_PATH=/path/to/config cap appliance deploy
+            or
+            cap appliance deploy -s local_config_path=/path/to/config
+        MSG
       end
     end
   end

--- a/lib/capistrano/tasks/newrelic.rake
+++ b/lib/capistrano/tasks/newrelic.rake
@@ -1,0 +1,6 @@
+namespace :newrelic do
+  task :report_deployment do
+    next unless fetch(:newrelic_notice_enabled, false)
+    invoke 'newrelic:notice_deployment'
+  end
+end


### PR DESCRIPTION
Refactor of Capistrano deployment:

- Move logic out of config/deploy.rb into capistrano tasks 
- Add Capistrano task for notifying NewRelic of deployments.
- Remove encrypted credentials from newrelic.yml
- Disable NewRelic agent in appliance

Notes:
Encrypted credentials do not work in newrelic.yml, since the file is parsed before Rails initializes. As a result, Rails.application.credentials is not accessible at that point. 

The NewRelic Capistrano announce task is disabled by default. To enable it, add the following to your environment-specific deploy config:

```
set :newrelic_notice_enabled, true
```
