### PR TITLE
Bugfix: mappings between two ontologies show links that are reversed

### DIFF
--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -10,6 +10,9 @@
           %th #{@target_ontology.name}
           %th Source
         - for map in @mappings
+          - map.classes.sort_by! do |c|
+            - ontology_id = c.links["ontology"].split("/").last
+            - ontology_id == @ontology.acronym ? 0 : 1
           %tr
             - cls = map.classes.shift
             %td


### PR DESCRIPTION
This PR resolves https://github.com/ncbo/bioportal_web_ui/issues/452, which was affecting many ontologies, not just OMO and AERO.

To reproduce the issue, navigate to https://bioportal.bioontology.org/ontologies/NCIT?p=mappings and click on any of the mapping links. The links inside the mapping table will be reversed.