### PR TITLE
Bugfix: class tree display indentations and bootstrap 5 compatibility

### DIFF
--- a/app/assets/stylesheets/components/tree_view.scss
+++ b/app/assets/stylesheets/components/tree_view.scss
@@ -1,7 +1,8 @@
-.tree-view-reuse-icon{
+.tree-view-reuse-icon {
     display: inline;
 }
-.tree-view-reuse-icon svg{
+
+.tree-view-reuse-icon svg {
     width: 13px;
 }
 
@@ -18,152 +19,174 @@ div.tree_error {
     padding: 0 3px;
 }
 
-#bd ul.simpleTree li{
+#bd ul.simpleTree li {
     margin-left: 0px;
     padding: 5px 0 0 10px;
 }
 
-#bd ul.simpleTree{
-margin-left:0px;
-margin-bottom:0px;
+#bd ul.simpleTree {
+    margin-left: 0px;
+    margin-bottom: 0px;
 }
 
 .simpleTree {
-margin:0;
-padding:0;
+    margin: 0;
+    padding: 0;
 
-a.tree-link {
-    display: inline-block;
-    padding: 5px;
-    text-wrap: wrap;
-    color: var(--primary-color) !important;
+    a.tree-link {
+        display: inline-block;
+        padding: 5px;
+        text-wrap: wrap;
+        color: var(--primary-color) !important;
+    }
+
+    a.tree-link.active {
+        cursor: default;
+        background-color: var(--light-color);
+        font-weight: bold;
+        border-radius: 3px;
+        padding: 7px 5px;
+    }
+
+    .tree-border-left {
+        border-left: 2px dotted #eee;
+        margin-left: 2px;
+    }
 }
 
-a.tree-link.active {
-    cursor: default;
-    background-color: var(--light-color);
-    font-weight: bold;
-    border-radius: 3px;
-    padding: 7px 5px;
-}
-
-.tree-border-left{
-    border-left: 2px dotted #eee;
-    margin-left: 2px;
-}
-}
 .simpleTree li {
-list-style: none;
-margin:0;
-padding:0 0 0 22px;
-line-height: 14px;
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 22px;
+    line-height: 14px;
 }
+
 .simpleTree li span {
-display:inline;
-clear: left;
-white-space: nowrap;
+    display: inline;
+    clear: left;
+    white-space: nowrap;
 }
+
 .simpleTree ul {
-margin:0;
-padding:0;
+    margin: 0;
+    padding: 0;
 }
+
 .simpleTree .root ul {
-margin:0;
+    margin: 0;
 }
+
 .simpleTree .root {
-margin-left:-16px;
-/*background: url(/images/tree/root.gif) no-repeat 16px 0 #ffffff;*/
+    margin-left: -16px;
+    /*background: url(/images/tree/root.gif) no-repeat 16px 0 #ffffff;*/
 }
+
 .simpleTree .line {
-margin:0 0 0 -16px;
-padding:0;
-line-height: 3px;
-height:3px;
-font-size:3px;
-background: image-url('jquery.simple.tree/line_bg.gif') 0 0 no-repeat transparent;
+    margin:0 0 0 -16px;
+    padding: 0;
+    line-height: 3px;
+    height: 3px;
+    font-size: 3px;
+    background: image-url('jquery.simple.tree/line_bg.gif') 0 0 no-repeat transparent;
 }
+
 .simpleTree .line-last {
-margin:0 0 0 -16px;
-padding:0;
-line-height: 3px;
-height:3px;
-font-size:3px;
-background: image-url('jquery.simple.tree/spacer.gif') 0 0 no-repeat transparent;
+    margin: 0 0 0 -16px;
+    padding: 0;
+    line-height: 3px;
+    height: 3px;
+    font-size: 3px;
+    background: image-url('jquery.simple.tree/spacer.gif') 0 0 no-repeat transparent;
 }
+
 .simpleTree .line-over {
-margin:0 0 0 -16px;
-padding:0;
-line-height: 3px;
-height:3px;
-font-size:3px;
-background: image-url('jquery.simple.tree/line_bg_over.gif') 0 0 no-repeat transparent;
+    margin:0 0 0 -16px;
+    padding: 0;
+    line-height: 3px;
+    height: 3px;
+    font-size: 3px;
+    background: image-url('jquery.simple.tree/line_bg_over.gif') 0 0 no-repeat transparent;
 }
+
 .simpleTree .line-over-last {
-margin:0 0 0 -16px;
-padding:0;
-line-height: 3px;
-height:3px;
-font-size:3px;
-background: image-url('jquery.simple.tree/line_bg_over_last.gif') 0 0 no-repeat transparent;
+    margin: 0 0 0 -16px;
+    padding: 0;
+    line-height: 3px;
+    height: 3px;
+    font-size: 3px;
+    background: image-url('jquery.simple.tree/line_bg_over_last.gif') 0 0 no-repeat transparent;
 }
+
 .simpleTree .folder-open {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/collapsable.gif') 0 -2px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/collapsable.gif') 0 -2px no-repeat #fff;
 }
+
 .simpleTree .folder-open-last {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/collapsable-last.gif') 0 -2px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/collapsable-last.gif') 0 -2px no-repeat #fff;
 }
+
 .simpleTree .folder-close {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/expandable.gif') 0 -2px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/expandable.gif') 0 -2px no-repeat #fff;
 }
+
 .simpleTree .folder-close-last {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/expandable-last.gif') 0 -2px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/expandable-last.gif') 0 -2px no-repeat #fff;
 }
+
 .simpleTree .doc {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/leaf.gif') 0 -1px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/leaf.gif') 0 -1px no-repeat #fff;
 }
+
 .simpleTree .doc-last {
-margin-left:-16px;
-background: image-url('jquery.simple.tree/leaf-last.gif') 0 -1px no-repeat #fff;
+    margin-left: -16px;
+    background: image-url('jquery.simple.tree/leaf-last.gif') 0 -1px no-repeat #fff;
 }
+
 .simpleTree .ajax {
-background: image-url('jquery.simple.tree/spinner.gif') no-repeat 0 0 #ffffff;
-height: 16px;
-display:none;
+    background: image-url('jquery.simple.tree/spinner.gif') no-repeat 0 0 #ffffff;
+    height: 16px;
+    display: none;
 }
+
 .simpleTree .ajax li {
-display:none;
-margin:0;
-padding:0;
+    display: none;
+    margin: 0;
+    padding: 0;
 }
+
 .simpleTree .trigger {
-display:inline;
-margin-left:-32px;
-width: 28px;
-height: 11px;
-cursor:pointer;
+    display: inline;
+    margin-left: -32px;
+    width: 28px;
+    height: 11px;
+    cursor: pointer;
 }
+
 .simpleTree .text {
-cursor: default;
-padding: 0 2px;
+    cursor: default;
+    padding: 0 2px;
 }
+
 .simpleTree .active {
-cursor: default;
-background-color: #B9D5E4;
-font-weight: bold;
-padding-top: 0px;
-padding-right: 2px;
-padding-bottom: 0px;
-padding-left: 2px;
+    cursor: default;
+    background-color: #B9D5E4;
+    font-weight: bold;
+    padding-top: 0px;
+    padding-right: 2px;
+    padding-bottom: 0px;
+    padding-left: 2px;
 }
+
 .simpleTree a, .simpleTree a:hover {
-text-decoration: none;
-color: black;
+    text-decoration: none;
+    color: black;
 }
+
 .simpleTree a:hover {
-cursor: pointer;
+    cursor: pointer;
 }

--- a/app/components/dropdown_container_component/dropdown_container_component.html.haml
+++ b/app/components/dropdown_container_component/dropdown_container_component.html.haml
@@ -4,7 +4,7 @@
       = title
     - else
       = render Display::HeaderComponent.new(text: @title, tooltip: @tooltip)
-    = image_tag("summary/arrow-down.svg", class: 'ml-2')
+    = image_tag("summary/arrow-down.svg", class: 'ms-2')
 
   .collapse{id: @id, class: open_class}
     - if content && !content.empty?

--- a/app/components/language_field_component/language_field_component.html.haml
+++ b/app/components/language_field_component/language_field_component.html.haml
@@ -2,7 +2,7 @@
   .d-flex.align-items-center.gap-1{data: {toggle: "tooltip"}, title: @label}
     = @icon ? inline_svg_tag(@icon, width: "17px", height: "17px") : flag_icon(lang_code)
     - if @label
-      %div.ml-1
+      %div.ms-1
         = @label
 - else
   = value

--- a/app/components/tree_link_component.rb
+++ b/app/components/tree_link_component.rb
@@ -41,7 +41,7 @@ class TreeLinkComponent < ViewComponent::Base
   end
 
   def border_left
-    !@child.hasChildren ? 'pl-3 tree-border-left' : ''
+    !@child.hasChildren ? 'ps-3 tree-border-left' : ''
   end
 
   def li_id

--- a/app/components/tree_view_component.rb
+++ b/app/components/tree_view_component.rb
@@ -21,7 +21,7 @@ class TreeViewComponent < ViewComponent::Base
 
   def tree_container(&block)
     if sub_tree?
-      content_tag(:ul, capture(&block), class: 'pl-2 tree-border-left')
+      content_tag(:ul, capture(&block), class: 'ps-2 tree-border-left')
     else
       content_tag(:div, class: 'tree_wrapper hide-if-loading') do
         content_tag(:ul, capture(&block), class: 'simpleTree root', data: { controller: 'simple-tree',

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -59,7 +59,7 @@ module OntologiesHelper
     text_color = submission[:status].to_s.eql?('retired') ? 'text-danger bg-danger-light' : 'text-warning bg-warning-light'
     text_content = submission[:status].to_s.eql?('retired') ? 'Retired' : 'Deprecated'
     style = "#{text_color} #{small && 'chip_button_small'}"
-    render ChipButtonComponent.new(class: "#{style} mr-1", text: text_content, type: clickable ? 'clickable' : 'static')
+    render ChipButtonComponent.new(class: "#{style} me-1", text: text_content, type: clickable ? 'clickable' : 'static')
   end
 
   def ontology_alternative_names(submission = @submission_latest)

--- a/app/views/layouts/_notices.html.haml
+++ b/app/views/layouts/_notices.html.haml
@@ -34,4 +34,4 @@
         }
       = tag.div(id: "notice_message", class: %w(alert alert-info), role: "alert") do
         %div= raw($SITE_NOTICE[message_name])
-        %a{href: "#", onclick: "close_message(); return false;", class: "pl-3"} [close]
+        %a{href: "#", onclick: "close_message(); return false;", class: "ps-3"} [close]

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -10,6 +10,9 @@
           %th #{@target_ontology.name}
           %th Source
         - for map in @mappings
+          - map.classes.sort_by! do |c|
+            - ontology_id = c.links["ontology"].split("/").last
+            - ontology_id == @ontology.acronym ? 0 : 1
           %tr
             - cls = map.classes.shift
             %td

--- a/app/views/ontologies/properties.html.haml
+++ b/app/views/ontologies/properties.html.haml
@@ -1,7 +1,7 @@
 = render TurboFrameComponent.new(id: 'properties',data: {"turbo-frame-target": "frame"}) do
   %div.ont-properties.py-3{data:{controller: 'container-splitter'}}
     %div#propTree{data:{'container-splitter-target': 'container'}}
-    %div#prop_contents.pl-3{data:{'container-splitter-target': 'container'}}
+    %div#prop_contents.ps-3{data:{'container-splitter-target': 'container'}}
 
   :plain
     <script id="property-details" type="text/x-handlebars-template">


### PR DESCRIPTION
The code recently contributed by AgroPortal uses an older version of Bootstrap, 4.x, while ours is a newer version, 5.x. 

In Bootstrap, certain style naming conventions changed from 4.x to 5.x (ex: "pl-3", padding-left-3 changed to "ps-3", padding-start-3, so the correct style wasn’t kicking in in the version you’re seeing. This PR addresses this issue, which affected the class tree display.

Tree with the bug:
<img width="507" height="531" alt="Screenshot 2025-08-08 at 10 46 40" src="https://github.com/user-attachments/assets/05d7e201-c70b-483e-b5b4-32c0fc8ddfaa" />

Tree fixed:
<img width="512" height="541" alt="Screenshot 2025-08-08 at 10 46 50" src="https://github.com/user-attachments/assets/32f87ec8-561d-4b83-927c-f834282d35b0" />
