### PR TITLE
Fix disappearing content in class permanent link dialog

### DIFF
--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -26,6 +26,7 @@ class ConceptsController < ApplicationController
     @concept = @ontology.explore.single_class({ full: true, language: request_lang }, params[:id])
 
     concept_not_found(params[:id]) if @concept.nil?
+    @current_purl = @concept.purl if Rails.configuration.settings.purl[:enabled]
     @notes = @concept.explore.notes
     render partial: 'show'
   end

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -28,12 +28,12 @@
 
   :javascript
     jQuery(document).ready(function(){
-      jQuery("#classPermalinkModal").on("shown.bs.modal", function (e) {
+      jQuery("#classPermalinkModal").off("shown.bs.modal").on("shown.bs.modal", function (e) {
         var currentPurl = jQuery("#classPermalink").data("current-purl");
         jQuery("#purl_input").val(currentPurl);
       })
 
-      jQuery("#purl_input").on("click", function () {
+      jQuery("#purl_input").off("click").on("click", function () {
         jQuery(this).select();
       });
     });


### PR DESCRIPTION
## Summary

- Fix the "Get a permanent link to this class" dialog failing to display the permanent link after switching between classes in the tree view
- Set `@current_purl` in `concepts#show` action to ensure the permalink is available when loading classes via Turbo Frame
- Add `.off()` before `.on()` for event handlers to prevent potential accumulation when Turbo Frame content is replaced

## Root Cause

When clicking a class in the tree view, the request is handled by `concepts#show` via Turbo Frame. However, `@current_purl` was only being set in `ontologies#classes`, not in `concepts#show`. This caused the `data-current-purl` attribute on the permalink button to be empty for all Turbo Frame-loaded classes.

## Test plan

- [x] Navigate to the Classes tab for any ontology (e.g., BRO)
- [x] Click the "Get a permanent link to this class" button - verify the link displays
- [x] Click a different class in the tree
- [x] Click the permanent link button again - verify the link displays correctly (previously it would flash and disappear)
- [x] Repeat for several more class selections - verify the link continues to work

Fixes #475

🤖 Generated with [Claude Code](https://claude.ai/code)