### PR TITLE
Fix unsafe open redirect on login

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -25,7 +25,7 @@ class LoginController < ApplicationController
         redirect = '/'
 
         if session[:redirect]
-          redirect = CGI.unescape(session[:redirect])
+          redirect = safe_redirect_path(CGI.unescape(session[:redirect]))
         end
 
         redirect_to redirect
@@ -122,5 +122,28 @@ class LoginController < ApplicationController
     end
 
     errors
+  end
+
+  # Sanitize a redirect URL to prevent open redirect attacks.
+  # Returns only relative paths or same-host paths; falls back to '/'.
+  def safe_redirect_path(url)
+    return '/' if url.blank?
+    return '/' if url.match?(%r{\A[/\\]{2}})
+
+    uri = URI.parse(url)
+
+    if uri.scheme.present? || uri.host.present?
+      if uri.host == request.host
+        path = uri.path.presence || '/'
+        path += "?#{uri.query}" if uri.query.present?
+        path
+      else
+        '/'
+      end
+    else
+      url
+    end
+  rescue URI::InvalidURIError
+    '/'
   end
 end

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class LoginControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @fake_user = OpenStruct.new(
+      username: 'testuser',
+      id: 'testuser',
+      apikey: 'fake-api-key',
+      admin?: false,
+      errors: nil,
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test@example.com',
+      subscription: nil
+    )
+  end
+
+  # Stub authentication to avoid hitting the external API.
+  # Yields to the block with authentication bypassed.
+  def with_stubbed_auth
+    LinkedData::Client::Models::User.stub(:authenticate, @fake_user) do
+      yield
+    end
+  end
+
+  # -- Redirect sanitization tests --
+
+  test 'login with no redirect param redirects to root' do
+    with_stubbed_auth do
+      get login_index_url
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with valid relative redirect preserves path' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=%2Fontologies"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/ontologies'
+    end
+  end
+
+  test 'login with protocol-relative redirect falls back to root' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=//evil.com"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with absolute external URL falls back to root' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=https://evil.com/phishing"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with encoded protocol-relative redirect falls back to root' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=%2F%2Fevil.com"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with backslash redirect falls back to root' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=\\\\evil.com"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with javascript URI falls back to root' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=javascript:alert(1)"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/'
+    end
+  end
+
+  test 'login with same-host absolute URL extracts path' do
+    with_stubbed_auth do
+      get "#{login_index_url}?redirect=http://#{host}/ontologies?p=classes"
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+      assert_redirected_to '/ontologies?p=classes'
+    end
+  end
+end

--- a/test/integration/login_flows_test.rb
+++ b/test/integration/login_flows_test.rb
@@ -85,4 +85,59 @@ class LoginFlowsTest < ActionDispatch::IntegrationTest
 
     assert_select '.flash.alert', /Welcome/
   end
+
+  test 'login with valid internal redirect preserves redirect path' do
+    get "#{login_index_url}?redirect=%2Fontologies"
+    assert_response :success
+
+    post login_index_url, params: {
+      user: { username: @user_bob.username, password: @user_bob.password }
+    }
+
+    assert_redirected_to '/ontologies'
+  end
+
+  test 'login with protocol-relative redirect falls back to root' do
+    get "#{login_index_url}?redirect=//evil.com"
+    assert_response :success
+
+    post login_index_url, params: {
+      user: { username: @user_bob.username, password: @user_bob.password }
+    }
+
+    assert_redirected_to '/'
+  end
+
+  test 'login with absolute external redirect falls back to root' do
+    get "#{login_index_url}?redirect=https://evil.com/phishing"
+    assert_response :success
+
+    post login_index_url, params: {
+      user: { username: @user_bob.username, password: @user_bob.password }
+    }
+
+    assert_redirected_to '/'
+  end
+
+  test 'login with encoded protocol-relative redirect falls back to root' do
+    get "#{login_index_url}?redirect=%2F%2Fevil.com"
+    assert_response :success
+
+    post login_index_url, params: {
+      user: { username: @user_bob.username, password: @user_bob.password }
+    }
+
+    assert_redirected_to '/'
+  end
+
+  test 'login with backslash redirect falls back to root' do
+    get "#{login_index_url}?redirect=\\\\evil.com"
+    assert_response :success
+
+    post login_index_url, params: {
+      user: { username: @user_bob.username, password: @user_bob.password }
+    }
+
+    assert_redirected_to '/'
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #397 — the login controller's `redirect` parameter was not validated, allowing open redirects to external hosts (e.g., `/login?redirect=//evil.com`). With Rails 7.0+ `raise_on_open_redirects`, this currently causes a 500 error rather than a graceful fallback.

- Adds `safe_redirect_path` private helper to `LoginController` that sanitizes the redirect URL before `redirect_to`
- Blocks protocol-relative URLs (`//evil.com`), backslash bypasses (`\\evil.com`), absolute external URLs, and `javascript:`/`data:` URIs
- Preserves valid internal redirects (relative paths and same-host absolute URLs)
- Falls back to `/` for any invalid or external redirect

## Test plan

- [x] New controller tests (`test/controllers/login_controller_test.rb`) with stubbed auth — 8 tests, all passing, no external API dependency
- [x] New integration tests (`test/integration/login_flows_test.rb`) for live API validation — covers same redirect scenarios with real authentication
- [x] Verify existing login flow still works on staging (login → redirect to referring page)
- [x] Verify malicious redirect URLs show root page instead of 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)