### PR TITLE
Add rel="nofollow" to feedback links

### DIFF
--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -26,7 +26,7 @@
         %ul{class: 'nav flex-column list-unstyled'}
           %li.nav-item
             = link_to('Contact Us', feedback_path, class: 'nav-link p-0',
-                      data: {controller: 'popup', action: 'click->popup#open'})
+                      rel: 'nofollow', data: {controller: 'popup', action: 'click->popup#open'})
           %li.nav-item
             = link_to('Documentation', Rails.configuration.settings.links[:help], class: 'nav-link p-0',
                       target: '_blank')

--- a/app/views/layouts/_topnav.html.haml
+++ b/app/views/layouts/_topnav.html.haml
@@ -52,7 +52,7 @@
           %ul.dropdown-menu.dropdown-menu-end
             %li
               = link_to("Submit feedback", feedback_path, id: "submitFeedbackMenuItem", class: "dropdown-item",
-                        data: {controller: 'popup', action: 'click->popup#open'})
+                        rel: 'nofollow', data: {controller: 'popup', action: 'click->popup#open'})
             %li
               %hr.dropdown-divider
             %li


### PR DESCRIPTION
## Summary
- Adds `rel="nofollow"` to the "Submit feedback" link in the top navigation dropdown
- Adds `rel="nofollow"` to the "Contact Us" link in the footer
- Supplements the existing `robots.txt` Disallow rule for `/feedback`

Closes #121

## Test plan
- [x] Verify both links still open the feedback popup as expected
- [x] Inspect rendered HTML to confirm `rel="nofollow"` attribute is present on both links

🤖 Generated with [Claude Code](https://claude.com/claude-code)