### PR TITLE
Display category chips by name instead of acronym

### DIFF
--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -97,9 +97,6 @@ module ComponentsHelper
                     value: value, tooltip: title, disabled: disabled, &block)
   end
 
-  alias :category_chip_component :group_chip_component
-
-
   def form_save_button(enable_loading: true)
     render Buttons::RegularButtonComponent.new(id: 'save-button', value: t('components.save_button'), variant: "primary", size: "slim", type: "submit", state: enable_loading ? 'animate' : '') do |btn|
       btn.icon_left do

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -130,9 +130,9 @@ module SubmissionInputsHelper
         hidden_field_tag('ontology[hasDomain][]') +
           sorted_categories.map do |category|
             content_tag(:div) do
-              category_chip_component(id: category[:acronym], name: "ontology[hasDomain][]",
-                                      object: category, value: category[:id],
-                                      checked: ontology.hasDomain&.any? { |x| x.eql?(category[:id]) })
+              chips_component(id: category[:acronym], name: 'ontology[hasDomain][]',
+                              label: category[:name], value: category[:id],
+                              checked: ontology.hasDomain&.any? { |x| x.eql?(category[:id]) })
             end
           end.join.html_safe
       end


### PR DESCRIPTION
- Call `chips_component` directly for category chips instead of going through the `group_chip_component` alias
- Category chips now display the category name as the label instead of the acronym
- Remove the unused `category_chip_component` alias from `components_helper.rb`