### PR TITLE
Remove Virtual Appliance 2.5 archive download

### DIFF
--- a/app/controllers/virtual_appliance_controller.rb
+++ b/app/controllers/virtual_appliance_controller.rb
@@ -4,14 +4,6 @@ class VirtualApplianceController < ApplicationController
 
   def index
     @user = session[:user]
-
-    @virtual_appliance_user = VirtualApplianceUser.where(user_id: @user.id)
-
-    @virtual_appliance_access = false
-    if !@virtual_appliance_user.nil? && !@virtual_appliance_user.empty? || @user.admin?
-      @virtual_appliance_access = true
-    end
-
     @va_users = VirtualApplianceUser.order(:user_id)
   end
 

--- a/app/views/virtual_appliance/index.html.haml
+++ b/app/views/virtual_appliance/index.html.haml
@@ -64,17 +64,6 @@
       |
       <a href="https://ontoportal.github.io/documentation/administration/steps/getting_started#amazon-aws-ami"> Amazon EC2</a>
 
-  -if @virtual_appliance_access
-    %h3 Archives
-    %p
-      The OntoPortal 2.5 Virtual Appliance is not longer offered for new
-      users. This archival distribution is available only as a backup for
-      those who registered for the Appliance before June 2020
-    %ul
-      %li
-        Version 2.5
-        =link_to 'OVF', 'https://www.bioontology.org/ontoportal-appliance/ontoportal-2.5.zip'
-
   -if @user.admin?
     %div{:style => "margin: 2em 0 0; padding: 1em 1em; border: solid thin gray; background-color: lightGray;"}
       %h1{:style => "margin-bottom: 15px;"} Admin: Add Users


### PR DESCRIPTION
## Summary
- Removes the `Archives` section from `app/views/virtual_appliance/index.html.haml` that offered the OntoPortal 2.5 OVF download link to a legacy allowlist.
- Removes the now-dead `@virtual_appliance_access` and `@virtual_appliance_user` instance variables from `VirtualApplianceController#index` that only existed to gate that block.

Partially addresses #481

## Rationale
Per the issue:

> The BioPortal Web UI Virtual Appliance page conditionally enables an archives feature for a set of legacy users, exposing an OVF download link for Virtual Appliance version 2.5. The archive feature should be removed; the list of users can be purged. The associated legacy user list can be purged since this information has already been migrated to the license server.

## Scope
- **Removed:** archive block + its gating variables (19 deletions, 0 additions).
- **Intentionally preserved:** the `VirtualApplianceUser` model, migrations, and admin allowlist UI on the same page. Data is already migrated to the license server so nothing is at risk, and the allowlist UI may be useful for future appliance-related features. A purge of the `virtual_appliance_users` table can be done separately if desired — it is out of scope for this view-removal PR.

## Test plan
- [ ] Manual: log in as a user in the allowlist and confirm the "Archives" heading and "Version 2.5 OVF" link are gone.
- [ ] Manual: log in as an admin and confirm the "Admin: Add Users" block below still renders correctly.
- No automated test was added: the change is a pure deletion of hardcoded static UI behind an admin/allowlist gate, with no conditional logic to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)