### PR TITLE
Feature/tom select remote users

### DIFF
--- a/app/components/input/select_component.rb
+++ b/app/components/input/select_component.rb
@@ -2,7 +2,7 @@
 
 class Input::SelectComponent < Input::InputFieldComponent
 
-  def initialize(id: nil, label: '', name:, value: [], selected: '', placeholder: '', error_message: '', helper_text: '', multiple: false, open_to_add_values: false, required: false,  data: {}, tooltip: nil)
+  def initialize(id: nil, label: '', name:, value: [], selected: '', placeholder: '', error_message: '', helper_text: '', multiple: false, open_to_add_values: false, required: false,  data: {}, tooltip: nil, remote_url: nil, remote_query_param: 'q')
     super(label: label, name: name, value: value, placeholder: placeholder, error_message: error_message,
           helper_text: helper_text, data: data, tooltip: tooltip)
     @values = value
@@ -11,6 +11,8 @@ class Input::SelectComponent < Input::InputFieldComponent
     @multiple = multiple
     @id = id
     @required = required
+    @remote_url = remote_url
+    @remote_query_param = remote_query_param
   end
 
   def call
@@ -18,6 +20,7 @@ class Input::SelectComponent < Input::InputFieldComponent
       render SelectInputComponent.new(id: @id, name: @name, values: @values, selected: @selected,
                                       placeholder: @placeholder, required: @required,
                                       multiple: @multiple, open_to_add_values: @open_to_add_values,
+                                      remote_url: @remote_url, remote_query_param: @remote_query_param,
                                       data: @data)
     end
   end

--- a/app/components/select_input_component.rb
+++ b/app/components/select_input_component.rb
@@ -2,7 +2,7 @@
 
 class SelectInputComponent < ViewComponent::Base
 
-  def initialize(id:, name:, values:, selected: nil, multiple: false, open_to_add_values: false, required: false, data: {}, placeholder: '', **html_options)
+  def initialize(id:, name:, values:, selected: nil, multiple: false, open_to_add_values: false, required: false, data: {}, placeholder: '', remote_url: nil, remote_query_param: 'q', **html_options)
     super
     @id = id || ''
     @name = name
@@ -13,6 +13,8 @@ class SelectInputComponent < ViewComponent::Base
     @placeholder = placeholder
     @data = data
     @required = required
+    @remote_url = remote_url
+    @remote_query_param = remote_query_param
     @html_options = html_options
   end
 
@@ -33,6 +35,10 @@ class SelectInputComponent < ViewComponent::Base
                          'select-input-open-add-value': open_to_add_values,
                          'select-input-required-value': required,
                        })
+    if @remote_url.present?
+      data[:'select-input-remote-url-value'] = @remote_url
+      data[:'select-input-remote-query-param-value'] = @remote_query_param
+    end
     data[:controller] = "#{data[:controller]} select-input"
 
     select_html_options = {

--- a/app/components/select_input_component/select_input_component_controller.js
+++ b/app/components/select_input_component/select_input_component_controller.js
@@ -55,7 +55,7 @@ export default class SelectInput extends Controller {
       const param = this.remoteQueryParamValue
       myOptions['preload'] = 'focus'
       myOptions['loadThrottle'] = 250
-      myOptions['shouldLoad'] = (q) => q.length >= 2
+      myOptions['shouldLoad'] = (q) => q.length >= 3
       myOptions['load'] = (query, callback) => {
         fetch(`${url}?${param}=${encodeURIComponent(query)}`, {
           headers: { Accept: 'application/json' }

--- a/app/components/select_input_component/select_input_component_controller.js
+++ b/app/components/select_input_component/select_input_component_controller.js
@@ -10,7 +10,9 @@ export default class SelectInput extends Controller {
     openAdd: { type: Boolean, default: false },
     required: { type: Boolean, default: false },
     searchable: { type: Boolean, default: true },
-    displayField: { type: String, default: SelectInput.DISPLAY_TEXT }
+    displayField: { type: String, default: SelectInput.DISPLAY_TEXT },
+    remoteUrl: { type: String, default: '' },
+    remoteQueryParam: { type: String, default: 'q' }
   }
 
   connect () {
@@ -29,7 +31,7 @@ export default class SelectInput extends Controller {
         }
       }
     }
-    
+
     myOptions['maxOptions'] = 100
 
     if(!this.searchableValue){
@@ -46,6 +48,22 @@ export default class SelectInput extends Controller {
 
     if (this.openAddValue) {
       myOptions['create'] = true
+    }
+
+    if (this.remoteUrlValue) {
+      const url = this.remoteUrlValue
+      const param = this.remoteQueryParamValue
+      myOptions['preload'] = 'focus'
+      myOptions['loadThrottle'] = 250
+      myOptions['shouldLoad'] = (q) => q.length >= 2
+      myOptions['load'] = (query, callback) => {
+        fetch(`${url}?${param}=${encodeURIComponent(query)}`, {
+          headers: { Accept: 'application/json' }
+        })
+          .then((r) => (r.ok ? r.json() : []))
+          .then(callback)
+          .catch(() => callback())
+      }
     }
 
     this.select = useTomSelect(this.element, myOptions, this.#triggerChange.bind(this))

--- a/app/components/select_input_component/select_input_component_controller.js
+++ b/app/components/select_input_component/select_input_component_controller.js
@@ -53,7 +53,6 @@ export default class SelectInput extends Controller {
     if (this.remoteUrlValue) {
       const url = this.remoteUrlValue
       const param = this.remoteQueryParamValue
-      myOptions['preload'] = 'focus'
       myOptions['loadThrottle'] = 250
       myOptions['shouldLoad'] = (q) => q.length >= 3
       myOptions['load'] = (query, callback) => {

--- a/app/controllers/concerns/ontology_updater.rb
+++ b/app/controllers/concerns/ontology_updater.rb
@@ -42,8 +42,6 @@ module OntologyUpdater
     @ontologies = LinkedData::Client::Models::Ontology.all(include: 'acronym', include_views: true, display_links: false, display_context: false)
     @categories = LinkedData::Client::Models::Category.all
     @groups = LinkedData::Client::Models::Group.all(display_links: false, display_context: false)
-    @user_select_list = LinkedData::Client::Models::User.all(include: 'username').map { |u| [u.username, u.id] }
-    @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
     @errors = response_errors(object)
     @selected_attributes = (Array(errors_attributes) + Array(params[:submission]&.keys)).uniq
     @ontology = ontology_from_params if @ontology.nil?

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -201,9 +201,6 @@ class OntologiesController < ApplicationController
 
     @groups = LinkedData::Client::Models::Group.all
     @groups.sort_by! { |g| g[:acronym].to_s.downcase }
-
-    @user_select_list = LinkedData::Client::Models::User.all(include: 'username').map { |u| [u.username, u.id] }
-    @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
   end
 
   # GET /ontologies/1
@@ -483,8 +480,6 @@ class OntologiesController < ApplicationController
     error_response = @ontology.update(cache_refresh_all: false)
     if response_error?(error_response)
       @categories = LinkedData::Client::Models::Category.all
-      @user_select_list = LinkedData::Client::Models::User.all.map {|u| [u.username, u.id]}
-      @user_select_list.sort! {|a,b| a[1].downcase <=> b[1].downcase}
       @errors = response_errors(error_response)
       @errors = {acronym: "Acronym already exists, please use another"} if error_response.status == 409
     else

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,15 +33,11 @@ class ProjectsController < ApplicationController
       redirect_to controller: 'login', action: 'index'
     else
       @project = LinkedData::Client::Models::Project.new
-      @user_select_list = LinkedData::Client::Models::User.all.map { |u| [u.username, u.id] }
-      @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
     end
   end
 
   def edit
     @project = LinkedData::Client::Models::Project.get(params[:id])
-    @user_select_list = LinkedData::Client::Models::User.all.map { |u| [u.username, u.id] }
-    @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
     @usedOntologies = @project.ontologyUsed || []
     @ontologies = LinkedData::Client::Models::Ontology.all
   end
@@ -66,8 +62,6 @@ class ProjectsController < ApplicationController
     end
 
     @project = LinkedData::Client::Models::Project.new(values: project_params)
-    @user_select_list = LinkedData::Client::Models::User.all.map { |u| [u.username, u.id] }
-    @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
     render action: 'new'
   end
 
@@ -77,8 +71,6 @@ class ProjectsController < ApplicationController
     error_response = @project.update(cache_refresh_all: false)
     if response_error?(error_response)
       @errors = response_errors(error_response)
-      @user_select_list = LinkedData::Client::Models::User.all.map { |u| [u.username, u.id] }
-      @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
       @usedOntologies = @project.ontologyUsed || []
       @ontologies = LinkedData::Client::Models::Ontology.all
       render :edit

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -18,8 +18,6 @@ class SubmissionsController < ApplicationController
     @groups = LinkedData::Client::Models::Group.all
     @groups.sort_by! { |g| g[:acronym].to_s.downcase }
 
-    @user_select_list = LinkedData::Client::Models::User.all(include: 'username').map { |u| [u.username, u.id] }
-    @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
     @is_update_ontology = true
     render "ontologies/new"
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,16 +22,15 @@ class UsersController < ApplicationController
     q = params[:q].to_s.strip
     return render(json: []) if q.length < 3
 
-    payload = Rails.cache.fetch("users_search:#{q.downcase}", expires_in: 5.minutes) do
-      results = LinkedData::Client::HTTP.get(
-        "#{LinkedData::Client.settings.rest_url}/users",
-        search: q,
-        include: 'username'
-      )
-      Array(results).first(25).map { |u| { value: u.id, text: u.username } }
-    end
-
-    render json: payload
+    response = LinkedData::Client::HTTP.get(
+      "#{LinkedData::Client.settings.rest_url}/users",
+      search: q,
+      include: 'username',
+      pagesize: 25,
+      page: 1
+    )
+    users = response.respond_to?(:collection) ? Array(response.collection) : Array(response)
+    render json: users.first(25).map { |u| { value: u.id, text: u.username } }
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
     return head(:unauthorized) unless session[:user]
 
     q = params[:q].to_s.strip
-    return render(json: []) if q.length < 2
+    return render(json: []) if q.length < 3
 
     payload = Rails.cache.fetch("users_search:#{q.downcase}", expires_in: 5.minutes) do
       results = LinkedData::Client::HTTP.get(

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,26 @@ class UsersController < ApplicationController
     end
   end
 
+  # JSON autocomplete for tom-select remote-loading dropdowns. Returns up to 25
+  # users matching `q` as `[{value: id, text: username}, ...]`. Requires login.
+  def search
+    return head(:unauthorized) unless session[:user]
+
+    q = params[:q].to_s.strip
+    return render(json: []) if q.length < 2
+
+    payload = Rails.cache.fetch("users_search:#{q.downcase}", expires_in: 5.minutes) do
+      results = LinkedData::Client::HTTP.get(
+        "#{LinkedData::Client.settings.rest_url}/users",
+        search: q,
+        include: 'username'
+      )
+      Array(results).first(25).map { |u| { value: u.id, text: u.username } }
+    end
+
+    render json: payload
+  end
+
   def show
     @user = LinkedData::Client::Models::User.get(escaped_id, include: 'all')
     @user_ontologies = @user.customOntology

--- a/app/helpers/inputs_helper.rb
+++ b/app/helpers/inputs_helper.rb
@@ -11,7 +11,8 @@ module InputsHelper
 
   def select_input(name:, values:, id: nil, label: nil, selected: nil, multiple: false, help: nil, open_to_add: false, required: false,
                    placeholder: nil,
-                   data: {})
+                   data: {},
+                   remote_url: nil, remote_query_param: 'q')
     render Input::SelectComponent.new(label: input_label(label, name), id: id || name, name: name, value: values,
                                       selected: selected,
                                       multiple: multiple,
@@ -19,7 +20,9 @@ module InputsHelper
                                       open_to_add_values: open_to_add,
                                       required: required,
                                       placeholder:  placeholder,
-                                      data: data)
+                                      data: data,
+                                      remote_url: remote_url,
+                                      remote_query_param: remote_query_param)
   end
 
   def number_input(name: , label: '', value: )

--- a/app/helpers/submission_inputs_helper.rb
+++ b/app/helpers/submission_inputs_helper.rb
@@ -113,12 +113,35 @@ module SubmissionInputsHelper
     content_tag(:div, out, class: 'my-1')
   end
 
-  def ontology_administered_by_input(ontology = @ontology, users_list = @user_select_list)
-    unless users_list
-      users_list = LinkedData::Client::Models::User.all(include: "username").map { |u| [u.username, u.id] }
-      users_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
+  def ontology_administered_by_input(ontology = @ontology)
+    user_select_input(
+      name: 'ontology[administeredBy]',
+      label: label_required(t('submission_inputs.administrators')),
+      selected: Array(ontology.administeredBy).presence || [session[:user].id],
+      multiple: true
+    )
+  end
+
+  # Renders a tom-select dropdown backed by /accounts/search?q=<term> instead
+  # of pre-loading the full user list. `selected` is an array of user URIs;
+  # we hydrate just those into <option> tags so existing values display as
+  # usernames on initial render. Remote loading kicks in once the user types.
+  def user_select_input(name:, selected:, label: '', multiple: true, required: false)
+    selected_ids = Array(selected).reject(&:blank?)
+    values = selected_ids.map do |id|
+      user = LinkedData::Client::Models::User.get(id, include: 'username')
+      [user&.username || id, id]
     end
-    select_input(label: label_required(t('submission_inputs.administrators')), name: "ontology[administeredBy]", values: users_list, selected: ontology.administeredBy || session[:user].id, multiple: true)
+
+    select_input(
+      name: name,
+      label: label,
+      multiple: multiple,
+      required: required,
+      values: values,
+      selected: selected_ids,
+      remote_url: search_users_path(format: :json)
+    )
   end
 
   def ontology_categories_input(ontology = @ontology, categories = @categories)
@@ -205,11 +228,6 @@ module SubmissionInputsHelper
   end
 
   def ontology_visibility_input(ontology = @ontology)
-    unless @user_select_list
-      @user_select_list = LinkedData::Client::Models::User.all(include: "username").map { |u| [u.username, u.id] }
-      @user_select_list.sort! { |a, b| a[1].downcase <=> b[1].downcase }
-    end
-
     render(Layout::RevealComponent.new(possible_values: %w[private public], selected: ontology.viewingRestriction)) do |c|
       c.with_button do
         select_input(label: label_required(t('submission_inputs.visibility')), name: "ontology[viewingRestriction]", required: true,
@@ -219,7 +237,12 @@ module SubmissionInputsHelper
 
       c.with_container do
         content_tag(:div, class: 'upload-ontology-input-field-container') do
-          select_input(label: t('submission_inputs.accounts_allowed', portal_name: portal_name), name: "ontology[acl]", values: @user_select_list, selected: ontology.acl, multiple: true)
+          user_select_input(
+            name: 'ontology[acl]',
+            label: t('submission_inputs.accounts_allowed', portal_name: portal_name),
+            selected: Array(ontology.acl),
+            multiple: true
+          )
         end
       end
     end

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -1,8 +1,3 @@
-:javascript
-  jQuery(document).ready(function(){
-    jQuery("#project_creator").chosen();
-  });
-
 - unless @errors.nil?
   .enable-lists{style: "color:red; padding-left:10px;"}
     %strong Errors On Form
@@ -45,7 +40,7 @@
       %td= text_field :project, :contacts, value: @project.contacts, :tabindex => 3
     %tr
       %th Administrators: *
-      %td= f.select :creator, @user_select_list, { selected: @project.creator || session[:user].id }, { multiple: true, :"data-placeholder" => "Select administrators", tabindex: 4 }    
+      %td= user_select_input(name: 'project[creator]', selected: @project.creator || [session[:user].id], multiple: true)
     %tr
       %th
         Homepage: *

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,11 @@ Rails.application.routes.draw do
 
   resources :projects, constraints: { id: /[^\/]+/ }
 
-  resources :users, path: :accounts, constraints: { id: /[\d\w\.\-\%\+\@ ]+/ }
+  resources :users, path: :accounts, constraints: { id: /[\d\w\.\-\%\+\@ ]+/ } do
+    collection do
+      get :search
+    end
+  end
 
   resources :mappings do
     member do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -43,6 +43,15 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
     assert_equal [], JSON.parse(response.body)
   end
 
+  test 'strips whitespace before measuring query length' do
+    login_fake_user
+    # '  al  ' is 6 chars but only 2 after strip — must short-circuit.
+    LinkedData::Client::HTTP.stub(:get, ->(*) { flunk 'API should not be called for whitespace-padded short query' }) do
+      get search_users_url(format: :json, q: '  al  ')
+    end
+    assert_equal [], JSON.parse(response.body)
+  end
+
   test 'returns up to 25 mapped {value, text} entries for a valid query' do
     login_fake_user
     fake_users = (1..30).map { |i| OpenStruct.new(id: "http://example.org/users/u#{i}", username: "user#{i}") }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -27,6 +27,27 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Stubs LinkedData::Client::HTTP.get so we can observe only the search-
+  # action's API call. Unrelated calls made during the request lifecycle
+  # (layouts, before_actions) get a benign empty response so the request
+  # completes; calls that look like our search endpoint (URL contains
+  # '/users' and params include :search) are recorded into `calls` and
+  # served `payload`.
+  def with_search_stub(payload: [])
+    calls = []
+    recorder = proc do |url, params = {}, *_|
+      if url.to_s.include?('/users') && params.is_a?(Hash) && params[:search]
+        calls << params[:search]
+        payload
+      else
+        []
+      end
+    end
+    LinkedData::Client::HTTP.stub(:get, recorder) do
+      yield calls
+    end
+  end
+
   test 'returns 401 when not logged in' do
     get search_users_url(format: :json, q: 'alex')
     assert_response :unauthorized
@@ -34,10 +55,9 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
 
   test 'returns empty array for query shorter than 3 chars' do
     login_fake_user
-    # Stub HTTP.get to a sentinel that would fail the assertion if reached;
-    # short queries must short-circuit before any API call.
-    LinkedData::Client::HTTP.stub(:get, ->(*) { flunk 'API should not be called for short query' }) do
+    with_search_stub do |calls|
       get search_users_url(format: :json, q: 'al')
+      assert_equal [], calls, 'search API should not be called for short query'
     end
     assert_response :success
     assert_equal [], JSON.parse(response.body)
@@ -45,9 +65,9 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
 
   test 'strips whitespace before measuring query length' do
     login_fake_user
-    # '  al  ' is 6 chars but only 2 after strip — must short-circuit.
-    LinkedData::Client::HTTP.stub(:get, ->(*) { flunk 'API should not be called for whitespace-padded short query' }) do
+    with_search_stub do |calls|
       get search_users_url(format: :json, q: '  al  ')
+      assert_equal [], calls, 'whitespace-padded short query should short-circuit'
     end
     assert_equal [], JSON.parse(response.body)
   end
@@ -55,7 +75,7 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
   test 'returns up to 25 mapped {value, text} entries for a valid query' do
     login_fake_user
     fake_users = (1..30).map { |i| OpenStruct.new(id: "http://example.org/users/u#{i}", username: "user#{i}") }
-    LinkedData::Client::HTTP.stub(:get, fake_users) do
+    with_search_stub(payload: fake_users) do
       get search_users_url(format: :json, q: 'user')
     end
     assert_response :success
@@ -67,30 +87,20 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
   test 'caches results so repeat queries hit the API only once' do
     login_fake_user
     fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
-    call_count = 0
-    counting_get = lambda do |*_args|
-      call_count += 1
-      fake_users
-    end
-    LinkedData::Client::HTTP.stub(:get, counting_get) do
+    with_search_stub(payload: fake_users) do |calls|
       get search_users_url(format: :json, q: 'alex')
       get search_users_url(format: :json, q: 'alex')
+      assert_equal 1, calls.size, 'second identical query should hit the cache'
     end
-    assert_equal 1, call_count, 'second identical query should hit the cache'
   end
 
   test 'cache key is case-insensitive' do
     login_fake_user
     fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
-    call_count = 0
-    counting_get = lambda do |*_args|
-      call_count += 1
-      fake_users
-    end
-    LinkedData::Client::HTTP.stub(:get, counting_get) do
+    with_search_stub(payload: fake_users) do |calls|
       get search_users_url(format: :json, q: 'ALEX')
       get search_users_url(format: :json, q: 'alex')
+      assert_equal 1, calls.size
     end
-    assert_equal 1, call_count
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -5,7 +5,6 @@ require 'minitest/mock'
 
 class UsersControllerSearchTest < ActionDispatch::IntegrationTest
   setup do
-    Rails.cache.clear
     @fake_user = OpenStruct.new(
       username: 'testuser',
       id: 'testuser',
@@ -84,23 +83,21 @@ class UsersControllerSearchTest < ActionDispatch::IntegrationTest
     assert_equal({ 'value' => 'http://example.org/users/u1', 'text' => 'user1' }, body.first)
   end
 
-  test 'caches results so repeat queries hit the API only once' do
+  # /users now returns a paged response (a Page-shaped object exposing
+  # `collection`, `nextPage`, `pageCount`) rather than a flat array. The
+  # search action must unpack `.collection` instead of treating the page
+  # object itself as iterable.
+  test 'unpacks paged response collection' do
     login_fake_user
-    fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
-    with_search_stub(payload: fake_users) do |calls|
-      get search_users_url(format: :json, q: 'alex')
-      get search_users_url(format: :json, q: 'alex')
-      assert_equal 1, calls.size, 'second identical query should hit the cache'
+    fake_users = (1..3).map { |i| OpenStruct.new(id: "http://example.org/users/u#{i}", username: "user#{i}") }
+    paged = OpenStruct.new(collection: fake_users, nextPage: nil, pageCount: 1)
+    with_search_stub(payload: paged) do
+      get search_users_url(format: :json, q: 'user')
     end
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 3, body.size
+    assert_equal({ 'value' => 'http://example.org/users/u1', 'text' => 'user1' }, body.first)
   end
 
-  test 'cache key is case-insensitive' do
-    login_fake_user
-    fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
-    with_search_stub(payload: fake_users) do |calls|
-      get search_users_url(format: :json, q: 'ALEX')
-      get search_users_url(format: :json, q: 'alex')
-      assert_equal 1, calls.size
-    end
-  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class UsersControllerSearchTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.cache.clear
+    @fake_user = OpenStruct.new(
+      username: 'testuser',
+      id: 'testuser',
+      apikey: 'fake-api-key',
+      admin?: false,
+      errors: nil,
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test@example.com',
+      subscription: nil
+    )
+  end
+
+  # Logs the fake user in by stubbing User.authenticate, so the integration
+  # session has session[:user] set without hitting the real API.
+  def login_fake_user
+    LinkedData::Client::Models::User.stub(:authenticate, @fake_user) do
+      post login_index_url, params: { user: { username: 'testuser', password: 'pass' } }
+    end
+  end
+
+  test 'returns 401 when not logged in' do
+    get search_users_url(format: :json, q: 'alex')
+    assert_response :unauthorized
+  end
+
+  test 'returns empty array for query shorter than 3 chars' do
+    login_fake_user
+    # Stub HTTP.get to a sentinel that would fail the assertion if reached;
+    # short queries must short-circuit before any API call.
+    LinkedData::Client::HTTP.stub(:get, ->(*) { flunk 'API should not be called for short query' }) do
+      get search_users_url(format: :json, q: 'al')
+    end
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test 'returns up to 25 mapped {value, text} entries for a valid query' do
+    login_fake_user
+    fake_users = (1..30).map { |i| OpenStruct.new(id: "http://example.org/users/u#{i}", username: "user#{i}") }
+    LinkedData::Client::HTTP.stub(:get, fake_users) do
+      get search_users_url(format: :json, q: 'user')
+    end
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal 25, body.size
+    assert_equal({ 'value' => 'http://example.org/users/u1', 'text' => 'user1' }, body.first)
+  end
+
+  test 'caches results so repeat queries hit the API only once' do
+    login_fake_user
+    fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
+    call_count = 0
+    counting_get = lambda do |*_args|
+      call_count += 1
+      fake_users
+    end
+    LinkedData::Client::HTTP.stub(:get, counting_get) do
+      get search_users_url(format: :json, q: 'alex')
+      get search_users_url(format: :json, q: 'alex')
+    end
+    assert_equal 1, call_count, 'second identical query should hit the cache'
+  end
+
+  test 'cache key is case-insensitive' do
+    login_fake_user
+    fake_users = [OpenStruct.new(id: 'http://example.org/users/alex', username: 'alex')]
+    call_count = 0
+    counting_get = lambda do |*_args|
+      call_count += 1
+      fake_users
+    end
+    LinkedData::Client::HTTP.stub(:get, counting_get) do
+      get search_users_url(format: :json, q: 'ALEX')
+      get search_users_url(format: :json, q: 'alex')
+    end
+    assert_equal 1, call_count
+  end
+end

--- a/test/helpers/submission_inputs_helper_test.rb
+++ b/test/helpers/submission_inputs_helper_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+# Tests for the user_select_input helper. Stubs the downstream `select_input`
+# helper to capture the args without rendering anything, and stubs User.get to
+# avoid hitting the API. The test verifies the helper's contract: which IDs
+# get hydrated, which get filtered, and what gets passed downstream.
+class SubmissionInputsHelperTest < ActionView::TestCase
+  include SubmissionInputsHelper
+
+  attr_accessor :captured_args
+
+  # Override select_input from InputsHelper for these tests so we can assert
+  # what user_select_input passes downstream without invoking the full
+  # ViewComponent rendering stack.
+  def select_input(**args)
+    @captured_args = args
+    'STUB'
+  end
+
+  setup do
+    @captured_args = nil
+  end
+
+  test 'rejects blank or nil IDs and skips API calls for them' do
+    fake = OpenStruct.new(username: 'alex', id: 'http://example.org/users/alex')
+    call_count = 0
+    counting_get = lambda do |*_args|
+      call_count += 1
+      fake
+    end
+    LinkedData::Client::Models::User.stub(:get, counting_get) do
+      user_select_input(name: 'x', selected: ['', nil, 'http://example.org/users/alex'])
+    end
+    assert_equal 1, call_count
+    assert_equal ['http://example.org/users/alex'], @captured_args[:selected]
+  end
+
+  test 'hydrates each pre-selected ID into a [username, id] tuple' do
+    fakes = {
+      'http://example.org/users/a' => OpenStruct.new(username: 'alpha', id: 'http://example.org/users/a'),
+      'http://example.org/users/b' => OpenStruct.new(username: 'beta',  id: 'http://example.org/users/b')
+    }
+    LinkedData::Client::Models::User.stub(:get, ->(id, *) { fakes[id] }) do
+      user_select_input(name: 'x', selected: fakes.keys)
+    end
+    assert_equal(
+      [['alpha', 'http://example.org/users/a'], ['beta', 'http://example.org/users/b']],
+      @captured_args[:values]
+    )
+  end
+
+  test 'falls back to id as the label when User.get returns nil' do
+    LinkedData::Client::Models::User.stub(:get, nil) do
+      user_select_input(name: 'x', selected: ['ghost-id'])
+    end
+    assert_equal [['ghost-id', 'ghost-id']], @captured_args[:values]
+  end
+
+  test 'sets remote_url to /accounts/search.json' do
+    LinkedData::Client::Models::User.stub(:get, nil) do
+      user_select_input(name: 'x', selected: [])
+    end
+    assert_equal '/accounts/search.json', @captured_args[:remote_url]
+  end
+
+  test 'defaults to multiple: true so the resulting select submits an array' do
+    LinkedData::Client::Models::User.stub(:get, nil) do
+      user_select_input(name: 'x', selected: [])
+    end
+    assert_equal true, @captured_args[:multiple]
+  end
+
+  test 'passes through name, label, and required to select_input' do
+    LinkedData::Client::Models::User.stub(:get, nil) do
+      user_select_input(name: 'ontology[acl]', label: 'Accounts allowed', selected: [], required: true)
+    end
+    assert_equal 'ontology[acl]', @captured_args[:name]
+    assert_equal 'Accounts allowed', @captured_args[:label]
+    assert_equal true, @captured_args[:required]
+  end
+end

--- a/test/integration/users_search_contract_test.rb
+++ b/test/integration/users_search_contract_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Contract tests assert what we *assume* about the upstream BioPortal API
+# wire shape. Unlike controller tests, they exercise no app code beyond the
+# API client — their job is to fail loudly the moment the API changes shape
+# under us, before that drift propagates into silent bugs in every controller
+# that handles the affected response.
+#
+# Background: ncbo/bioportal_web_ui#509 shipped a users#search action whose
+# unit tests stubbed LinkedData::Client::HTTP.get with a hand-rolled flat-
+# array fake. PR ncbo/bioportal_web_ui#510 had already changed /users to
+# return a paged response (an object with .collection, .nextPage, .pageCount).
+# The stub-based tests stayed green because the fake never matched reality;
+# the bug only surfaced when a user typed in the autocomplete. A contract
+# test catches that class of drift in CI, not in production.
+class UsersSearchContractTest < ActionDispatch::IntegrationTest
+  test 'GET /users?search= returns a paged-collection shape' do
+    response = begin
+      LinkedData::Client::HTTP.get(
+        "#{LinkedData::Client.settings.rest_url}/users",
+        search: 'admin', include: 'username', pagesize: 5, page: 1
+      )
+    rescue StandardError => e
+      skip "Upstream /users unreachable (#{e.class}: #{e.message}). " \
+           'Check BIOPORTAL_API_URL / BIOPORTAL_API_KEY or staging health.'
+    end
+
+    # Page-level shape: every caller that paginates this endpoint
+    # (admin#_users walks nextPage; users#search takes the first page) relies
+    # on these accessors. If any disappear, both controllers break silently.
+    %i[collection nextPage pageCount].each do |attr|
+      assert response.respond_to?(attr),
+             "paged response missing :#{attr} — upstream shape changed?"
+    end
+    assert_kind_of Array, response.collection,
+                   ':collection should be an Array of user records'
+
+    # Per-item shape: only assert when results came back. A zero-result
+    # environment isn't a contract violation; missing :id/:username on the
+    # user model is.
+    user = response.collection.first
+    skip 'no users matched "admin"; cannot assert per-item shape' if user.nil?
+
+    assert user.respond_to?(:id),
+           'user item missing :id — User model shape changed?'
+    assert user.respond_to?(:username),
+           'user item missing :username — include=username may not be honored'
+    assert_kind_of String, user.id
+    assert_kind_of String, user.username
+  end
+end


### PR DESCRIPTION
## Summary
Replaces full-User-list <option> tags (~22k entries) on three forms with a remote tom-select dropdown backed by a new `GET /accounts/search?q=` JSON endpoint. Adds remote_url: mode to the existing SelectInputComponent and a user_select_input helper that hydrates only currently-selected IDs into <option> tags.

 ## Details
   - Adds a `GET /accounts/search?q=<term>` JSON endpoint that proxies the BioPortal REST API's `?search=` parameter, returning up to 25
   `{value, text}` rows. Login required; results cached for 5 minutes per (case-insensitive) query.
   - Adds a `remote_url:` mode to `SelectInputComponent` (and threads it through `Input::SelectComponent` and the `select_input` helper) that
    wires tom-select's `load`/`preload`/`shouldLoad`/`loadThrottle` callbacks to the new endpoint. Min query length is 3.
   - Adds a `user_select_input` helper that renders a remote-mode dropdown and hydrates `<option>` tags only for currently-selected user IDs
   (so existing values display correctly on edit forms) instead of rendering the full ~22k-user list.
   - Converts the three visible offenders to the new helper:
     - Ontology administrators (`ontology[administeredBy]`)
     - Ontology ACL / accounts allowed (`ontology[acl]`)
     - Project creator/administrator (`project[creator]`) — also drops the legacy jQuery `.chosen()` initializer.
   - Removes the now-dead `@user_select_list = User.all...` blocks from submissions / ontologies / projects controllers and the `ontology_updater` concern.

   Closes ncbo/bioportal_web_ui#508
   
## Out of scope
   The admin user-management table (`users#index`, `admin#users`) still calls `User.all`. That's a paginate/filter problem on the table itself, not a select-dropdown problem, and is best handled separately.