### PR TITLE
Fix: address /users timeouts (signup/ontology create) and Admin Users JS error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'iso-639', '~> 0.3.6'
 gem 'dotenv-rails', groups: [:test]
 
 # Custom API client
-gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', branch: 'fix/slow-users-endpoint'
+gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', tag: 'v2.9.0'
 
 gem 'rexml', '~> 3'
 

--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem 'iso-639', '~> 0.3.6'
 gem 'dotenv-rails', groups: [:test]
 
 # Custom API client
-gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', tag: 'v2.8.1'
+gem 'ontologies_api_client', github: 'ncbo/ontologies_api_ruby_client', branch: 'fix/slow-users-endpoint'
 
 gem 'rexml', '~> 3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ncbo/ontologies_api_ruby_client.git
-  revision: 85498969878f8c4db9e43c8e709735a1e433d18e
-  tag: v2.8.1
+  revision: dad23b925e9b963f2b64872544ac3d4f884d2ac4
+  branch: fix/slow-users-endpoint
   specs:
     ontologies_api_client (2.8.1)
       activesupport (= 8.0.3)
@@ -577,6 +577,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-darwin
   x86_64-linux-gnu

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ncbo/ontologies_api_ruby_client.git
-  revision: dad23b925e9b963f2b64872544ac3d4f884d2ac4
-  branch: fix/slow-users-endpoint
+  revision: 3c3456503f4d2ff681d6f99bbee68598924b74c1
+  tag: v2.9.0
   specs:
-    ontologies_api_client (2.8.1)
+    ontologies_api_client (2.9.0)
       activesupport (= 8.0.3)
       addressable (~> 2.8)
       excon

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -305,10 +305,27 @@ class AdminController < ApplicationController
   end
 
   def _users
-    response = { users: {}, errors: '', success: '' }
+    response = { users: [], errors: '', success: '' }
     start = Time.now
     begin
-      response[:users] = JSON.parse(LinkedData::Client::HTTP.get(USERS_URL, { include: 'all' }, raw: true))
+      # /users now always returns a paged response. Walk nextPage links and
+      # concatenate `collection` so the frontend keeps receiving a flat array.
+      # The is_a?(Hash) branch tolerates the legacy flat-array shape in case
+      # we ever hit an older API.
+      users = []
+      page = 1
+      loop do
+        raw = JSON.parse(LinkedData::Client::HTTP.get(USERS_URL, { include: 'all', pagesize: 5000, page: page }, raw: true))
+        if raw.is_a?(Hash) && raw['collection'].is_a?(Array)
+          users.concat(raw['collection'])
+          break unless raw['nextPage']
+          page = raw['nextPage']
+        else
+          users = raw
+          break
+        end
+      end
+      response[:users] = users
 
       response[:success] = "users successfully retrieved in  #{Time.now - start}s"
       Log.add :debug, "Users - retrieved #{response[:users].length} users in #{Time.now - start}s"

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'minitest/mock'
+
+class AdminControllerTest < ActionDispatch::IntegrationTest
+  # Note: GET /admin/users currently has no admin-only enforcement (no
+  # before_action on AdminController, and the `users` action doesn't check
+  # session[:user]&.admin?). If that's tightened later, seed an admin
+  # session in setup — e.g. by stubbing ApplicationController#current_user_admin?
+  # to return true, or by signing in as an admin fixture.
+
+  # Regression: /users now always returns a paged response. _users must walk
+  # nextPage and concatenate `collection` so the frontend keeps receiving a
+  # flat Array. Without this, the Admin Users tab JS at bp_admin.js:904
+  # throws "Uncaught TypeError: users.forEach is not a function".
+  test '_users flattens a multi-page paged /users response' do
+    page1 = {
+      'page' => 1, 'pageCount' => 2, 'totalCount' => 3, 'nextPage' => 2,
+      'collection' => [sample_user('a'), sample_user('b')]
+    }
+    page2 = {
+      'page' => 2, 'pageCount' => 2, 'totalCount' => 3, 'nextPage' => nil,
+      'collection' => [sample_user('c')]
+    }
+
+    calls = []
+    fake_get = lambda do |_url, params, _opts|
+      calls << params
+      (params[:page] == 2 ? page2 : page1).to_json
+    end
+
+    LinkedData::Client::HTTP.stub :get, fake_get do
+      get '/admin/users'
+      assert_response :success
+
+      body = JSON.parse(@response.body)
+      assert_kind_of Array, body['users'], 'frontend contract: data["users"] must be an Array'
+      assert_equal %w[a b c], body['users'].map { |u| u['username'] }
+      assert_empty body['errors']
+    end
+
+    assert_equal 2, calls.length, 'should walk both pages'
+    assert_equal 5000, calls.first[:pagesize], 'should request large pagesize to minimize round trips'
+    assert_equal 2, calls.last[:page], 'second call should request page=2'
+  end
+
+  # Back-compat: tolerates the legacy flat-Array response shape during the
+  # rollout window when the deployed API may not yet enforce pagination.
+  test '_users tolerates a flat-array response from a non-paginated API' do
+    legacy = [sample_user('a'), sample_user('b')]
+
+    LinkedData::Client::HTTP.stub :get, ->(*) { legacy.to_json } do
+      get '/admin/users'
+      assert_response :success
+
+      body = JSON.parse(@response.body)
+      assert_kind_of Array, body['users']
+      assert_equal %w[a b], body['users'].map { |u| u['username'] }
+    end
+  end
+
+  private
+
+  def sample_user(name)
+    {
+      '@id' => "http://test/users/#{name}",
+      'username' => name,
+      'email' => "#{name}@test",
+      'role' => ['LIBRARIAN'],
+      'firstName' => name.upcase,
+      'lastName' => "#{name.upcase}-last",
+      'created' => '2026-01-01'
+    }
+  end
+end


### PR DESCRIPTION
## Summary
- Fix in `ontologies_api_client` to auto-flatten the new paged `/users` responses. Also slims default `User` attrs (drops `customOntology`, tokens, hashes, JSON-LD context, HATEOAS links), and provides an internal `pagesize: 5_000` for the page walk. See ncbo/ontologies_api_ruby_client#55 for details.
- Fix `AdminController#_users` to handle the new paged response shape. The endpoint uses raw HTTP (bypassing the `ontologies_api_ruby_client ` gem) and was `JSON.parse`-ing the response into a Hash and storing it directly under `:users`, but the Admin Users tab JS does `data['users'].forEach(...)` and threw `Uncaught TypeError: users.forEach is not a function`. 
- Add `test/controllers/admin_controller_test.rb` covering both response shapes the controller now has to handle (paged Hash + legacy flat Array), so this regression can't quietly come back. Tests stub `LinkedData::Client::HTTP.get` and assert the frontend's `data['users']` Array contract

## Why
Production users were unable to create ontologies, with `Faraday::TimeoutError` from controllers calling `LinkedData::Client::Models::User.all`. The `/users?include=all` endpoint's response time grew linearly with user count (per-row `serialize_filter → admin? → bring(role:[:role])` N+1 over the requesting user, compounded by no pagination), exceeding Faraday's 60s read timeout at production scale (~5,300 users).

## Cross-repo rollout
This is the final piece of a four-repo coordinated fix:
1. ✅ ncbo/ontologies_linked_data#286 (merged) — idempotent `User#admin?`, drop inverse attrs from auth load
2. ✅ ncbo/ontologies_api#216 — mandatory `/users` pagination + `/search` and `/property_search` 500 fix
3. ✅ ncbo/ontologies_api_ruby_client#55 — auto-flatten paged responses, slim `User` attrs
4. **This PR**

## Specific case in point
The gem bump of `ontologies_api_ruby_client` alone fixes the original production blocker (signup, ontology creation, the New Ontology admin-user dropdown) because every controller that calls `Models::User.all` goes through the new client's auto-flatten + slim attrs. The `_users` controller fix is needed *additionally* because that one path bypasses the gem and hits `LinkedData::Client::HTTP.get(USERS_URL, …, raw: true)` directly.

## Test plan
- [x] Admin Console > Users tab loads, populates table with expected user count, no JS errors in console
- [x] User signup (`/accounts/new`) completes without timeout
- [x] New Ontology form (`/ontologies/new`) loads without timeout (admin-user dropdown populates)
- [x] Custom ontology assignment, password reset, notification subscriptions still function
- [x] Verify against staging or a local API running the matching `ontologies_api` branch