### PR TITLE
Adopt server-side pagination for admin Users tab

### DIFF
--- a/app/assets/javascripts/bp_admin.js
+++ b/app/assets/javascripts/bp_admin.js
@@ -776,7 +776,7 @@ function showOntologiesToggleLinks(problemOnly) {
 jQuery(".admin.index").ready(function() {
   // display ontologies table on load
   displayOntologies({}, DUMMY_ONTOLOGY);
-  displayUsers({});
+  displayUsers();
   UpdateCheck.act();
 
   // make sure facebox window is empty before populating it
@@ -897,62 +897,37 @@ jQuery(".admin.index").ready(function() {
 
 
 /* users part */
-function populateUserRows(data) {
-    let users = data['users'];
-    let allRows = [];
-    // let hideFields = ["format", "administeredBy", "date_created", "report_date_updated", "errErrorStatus", "errMissingStatus", "problem", "logFilePath"];
-    users.forEach(user =>{
-        let id = '<a href="'+ user['@id']+'" >' + user['@id'] + '</a>';
-        let email = user['email'];
-        let username = user['username'];
-        let roles = user['role'];
-        let firstname = user['firstName']
-        let lastname = user['lastName']
-        let created = user['created']
-        let actions = [
-            '<a href="/accounts/'+ user['username'] +'"  class="mx-1">Detail</a>' ,
-            '<a href="javascript:;" class="delete-user mx-1" data-account-name="' + username + '">Delete</a>',
-            '<a href="/login_as/'+ encodeURIComponent(username) +'" class="mx-1">Login as</a>',
-
-        ]
-        let row = [firstname, lastname, username, email , roles , id , created , actions.join('|')];
-        allRows.push(row);
-    })
-
-    return allRows;
-}
-
-function displayUsers(data) {
-    let ontTable = null;
-    let allRows
+function displayUsers() {
     if (jQuery.fn.dataTable.isDataTable('#adminUsers')) {
-        ontTable = jQuery('#adminUsers').DataTable();
+        return jQuery('#adminUsers').DataTable();
+    }
 
-        if (ontology === DUMMY_ONTOLOGY) {
-            // refreshing entire table
-            allRows = populateUserRows(data);
-            ontTable.clear();
-            ontTable.rows.add(allRows);
-            ontTable.draw();
-        } else {
-            // refreshing individual row
-        }
-    } else {
-        ontTable = jQuery("#adminUsers").DataTable({
+    return jQuery("#adminUsers").DataTable({
+            "serverSide": true,
             "ajax": {
                 "url": "/admin/users",
                 "contentType": "application/json",
-                "dataSrc": function (json) {
-                    return populateUserRows(json);
+                "data": function (d) {
+                    var columnToAttr = ['firstName', 'lastName', 'username', 'email', 'role', null, 'created', null];
+                    var params = {
+                        draw: d.draw,
+                        page: Math.floor(d.start / d.length) + 1,
+                        pagesize: d.length,
+                        search: d.search.value
+                    };
+                    if (d.order && d.order.length) {
+                        var attr = columnToAttr[d.order[0].column];
+                        if (attr) {
+                            params.sortby = attr;
+                            params.order = d.order[0].dir;
+                        }
+                    }
+                    return params;
                 }
             },
             "rowCallback": function(row, data, index) {
-                var acronym = jQuery('td:nth-child(3)', row).text();
-
-                jQuery(row).attr("id", "tr_" + acronym);
-                if (data[data.length - 1] === true) {
-                    jQuery(row).addClass("problem");
-                }
+                var username = jQuery('td:nth-child(3)', row).text();
+                jQuery(row).attr("id", "tr_" + username);
             },
             "initComplete": function(settings, json) {
             },
@@ -1013,11 +988,10 @@ function displayUsers(data) {
             "paging": true,
             "pageLength": 100,
             "ordering": true,
+            "order": [[2, "asc"]],
             "responsive": true,
             "stripeClasses": ["", "alt"],
         });
-    }
-    return ontTable;
 }
 
 function DeleteUsers(user) {

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,8 +12,6 @@ class AdminController < ApplicationController
   REPORT_NEVER_GENERATED = 'NEVER GENERATED'
 
   def index
-    @users = LinkedData::Client::Models::User.all
-
     if session[:user].nil? || !session[:user].admin?
       redirect_to controller: 'login', action: 'index', redirect: '/admin'
     else
@@ -305,33 +303,41 @@ class AdminController < ApplicationController
   end
 
   def _users
-    response = { users: [], errors: '', success: '' }
-    start = Time.now
-    begin
-      # /users now always returns a paged response. Walk nextPage links and
-      # concatenate `collection` so the frontend keeps receiving a flat array.
-      # The is_a?(Hash) branch tolerates the legacy flat-array shape in case
-      # we ever hit an older API.
-      users = []
-      page = 1
-      loop do
-        raw = JSON.parse(LinkedData::Client::HTTP.get(USERS_URL, { include: 'all', pagesize: 5000, page: page }, raw: true))
-        if raw.is_a?(Hash) && raw['collection'].is_a?(Array)
-          users.concat(raw['collection'])
-          break unless raw['nextPage']
-          page = raw['nextPage']
-        else
-          users = raw
-          break
-        end
-      end
-      response[:users] = users
+    start_time = Time.now
+    page = (params[:page].presence || 1).to_i
+    pagesize = (params[:pagesize].presence || 100).to_i
+    search = params[:search].presence
+    draw = params[:draw].to_i
 
-      response[:success] = "users successfully retrieved in  #{Time.now - start}s"
-      Log.add :debug, "Users - retrieved #{response[:users].length} users in #{Time.now - start}s"
-    rescue StandardError => e
-      response[:errors] = "Problem retrieving users  - #{e.message}"
+    api_params = { include: 'all', page: page, pagesize: pagesize }
+    if search
+      api_params[:search] = search
+      api_params[:search_fields] = 'all'
     end
-    response
+    api_params[:sortby] = params[:sortby] if params[:sortby].presence
+    api_params[:order] = params[:order] if params[:order].presence
+
+    begin
+      raw = JSON.parse(LinkedData::Client::HTTP.get(USERS_URL, api_params, raw: true))
+      users = raw.is_a?(Hash) ? Array(raw['collection']) : Array(raw)
+      total = raw.is_a?(Hash) ? raw['totalCount'].to_i : users.length
+
+      Log.add :debug, "Users - retrieved page #{page} (#{users.length} of #{total}) in #{Time.now - start_time}s"
+
+      {
+        draw: draw,
+        recordsTotal: total,
+        recordsFiltered: total,
+        data: users.map { |user| helpers.user_datatable_row(user) }
+      }
+    rescue StandardError => e
+      {
+        draw: draw,
+        recordsTotal: 0,
+        recordsFiltered: 0,
+        data: [],
+        error: "Problem retrieving users - #{e.message}"
+      }
+    end
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -45,7 +45,7 @@ class LoginController < ApplicationController
       return
     end
 
-    user = params[:login_as]
+    user = params[:username]
     new_user = LinkedData::Client::Models::User.find_by_username(user).first
 
     if new_user

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -20,7 +20,7 @@ module Admin::UsersHelper
     safe_join([
       link_to('Detail', "/accounts/#{username}", class: 'mx-1'),
       link_to('Delete', 'javascript:;', class: 'delete-user mx-1', data: { account_name: username }),
-      link_to('Login as', "/login_as/#{ERB::Util.url_encode(username)}", class: 'mx-1')
+      link_to('Login as', login_as_path(username: username), class: 'mx-1')
     ], '|')
   end
 

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -14,7 +14,7 @@ module Admin
         h(user['email']),
         h(Array(user['role']).join(', ')),
         link_to(user_id, user_id),
-        h(user['created']),
+        user_created_at_cell(user['created']),
         user_datatable_actions(username)
       ]
     end
@@ -27,6 +27,14 @@ module Admin
         link_to('Login as', login_as_path(username: username), class: 'mx-1')
       ]
       safe_join(links, '|')
+    end
+
+    def user_created_at_cell(created)
+      return '' if created.blank?
+
+      Time.parse(created).strftime('%Y-%m-%d %H:%M')
+    rescue ArgumentError
+      h(created)
     end
   end
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,27 +1,32 @@
-module Admin::UsersHelper
+# frozen_string_literal: true
 
-  def user_datatable_row(user)
-    username = user['username'].to_s
-    user_id = user['@id'].to_s
+module Admin
+  module UsersHelper
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def user_datatable_row(user)
+      username = user['username'].to_s
+      user_id = user['@id'].to_s
 
-    [
-      h(user['firstName']),
-      h(user['lastName']),
-      h(username),
-      h(user['email']),
-      h(Array(user['role']).join(', ')),
-      link_to(user_id, user_id),
-      h(user['created']),
-      user_datatable_actions(username)
-    ]
+      [
+        h(user['firstName']),
+        h(user['lastName']),
+        h(username),
+        h(user['email']),
+        h(Array(user['role']).join(', ')),
+        link_to(user_id, user_id),
+        h(user['created']),
+        user_datatable_actions(username)
+      ]
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def user_datatable_actions(username)
+      links = [
+        link_to('Detail', "/accounts/#{username}", class: 'mx-1'),
+        link_to('Delete', 'javascript:;', class: 'delete-user mx-1', data: { account_name: username }),
+        link_to('Login as', login_as_path(username: username), class: 'mx-1')
+      ]
+      safe_join(links, '|')
+    end
   end
-
-  def user_datatable_actions(username)
-    safe_join([
-      link_to('Detail', "/accounts/#{username}", class: 'mx-1'),
-      link_to('Delete', 'javascript:;', class: 'delete-user mx-1', data: { account_name: username }),
-      link_to('Login as', login_as_path(username: username), class: 'mx-1')
-    ], '|')
-  end
-
 end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,27 @@
+module Admin::UsersHelper
+
+  def user_datatable_row(user)
+    username = user['username'].to_s
+    user_id = user['@id'].to_s
+
+    [
+      h(user['firstName']),
+      h(user['lastName']),
+      h(username),
+      h(user['email']),
+      h(Array(user['role']).join(', ')),
+      link_to(user_id, user_id),
+      h(user['created']),
+      user_datatable_actions(username)
+    ]
+  end
+
+  def user_datatable_actions(username)
+    safe_join([
+      link_to('Detail', "/accounts/#{username}", class: 'mx-1'),
+      link_to('Delete', 'javascript:;', class: 'delete-user mx-1', data: { account_name: username }),
+      link_to('Login as', "/login_as/#{ERB::Util.url_encode(username)}", class: 'mx-1')
+    ], '|')
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,7 +144,7 @@ Rails.application.routes.draw do
   get '/lost_pass' => 'login#lost_password'
   get '/reset_password' => 'login#reset_password'
   post '/accounts/:id/custom_ontologies' => 'users#custom_ontologies', :as => :custom_ontologies
-  get '/login_as/:login_as' => 'login#login_as', constraints: { login_as:  /[\d\w\.\-\%\+ ]+/ }
+  get '/login_as/*username' => 'login#login_as', as: :login_as, format: false
   post '/login/send_pass', to: 'login#send_pass'
   get 'password', to: 'passwords#edit', as: :edit_password
   patch 'password', to: 'passwords#update'


### PR DESCRIPTION
## Summary

- Adopt DataTables server-side pagination for the admin Users tab so each request fetches a single page from `/users` (`page`, `pagesize`, `search`, `search_fields=all`, `sortby`, `order`) instead of walking the full ~21k-user collection.
- Remove the unused `@users = LinkedData::Client::Models::User.all` in `AdminController#index` that was triggering an identical full-collection fetch on every Admin page load.
- Extract row HTML into `Admin::UsersHelper` so the controller stays presentation-free (uses `link_to` / `safe_join` for automatic escaping).
- Add a named `login_as` route (wildcard `*username` with `format: false`) so `login_as_path` is generated and handles arbitrary username characters (`@`, `.`, etc.). Rename the URL param from `:login_as` to `:username` and update `LoginController#login_as` accordingly.
- Format the "Created at" column as `YYYY-MM-DD HH:MM` via a new `user_created_at_cell` helper instead of dumping the raw ISO 8601 string.
- Address RuboCop warnings in `Admin::UsersHelper`: add `frozen_string_literal`, switch to nested namespace, extract the `safe_join` array into a local variable, and suppress `Metrics/AbcSize` / `Metrics/MethodLength` on `user_datatable_row` (row width is data, not complexity).

Closes #411.

## Dependencies

Search across `username`, `email`, `firstName`, and `lastName` requires the API to support `?search_fields=all` (added in ontoportal/ontologies_api#226). Without that build, the Filter box falls back to username-only matching, which is the prior behavior.

## Test plan

- [x] Navigate to `/admin` and click the Users tab — table loads quickly without DataTables warning
- [x] Verify default sort is **Username ascending**
- [x] Click each sortable column header (First Name, Last Name, Username, Email, Roles, Created at) and verify the order changes server-side and persists across page navigation
- [x] Type a username substring in the Filter box — matches across pages
- [x] Type an email / first name / last name substring — matches (requires API with `search_fields=all`)
- [x] Paginate forward/back — table updates
- [x] Delete a user via the row action — row disappears
- [x] Click "Login as" on a row — login flow works
- [x] Click "Detail" on a row — account page opens
- [x] "Created at" column displays as `YYYY-MM-DD HH:MM` rather than raw ISO 8601

🤖 Generated with [Claude Code](https://claude.com/claude-code)