### PR TITLE
Fix stale 500 error page wording (#144); pin minitest for the Rails 8 test runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,14 @@ docker compose run test bin/rails test:system
 
 ### Notes
 
+- **Minitest must stay on the 5.x series while on Rails 8.0.x.** Minitest 6.x
+  changed `run_suite`'s calling convention, which is incompatible with the Rails
+  8.0.x test runner (`railties` `test_unit/line_filtering`) and crashes
+  `bin/rails test` before any test runs (`wrong number of arguments` in
+  `line_filtering.rb`). The `Gemfile` pins `minitest ~> 5.25`; don't let it float
+  to 6.x. To verify app behavior when the harness is wedged, `rails runner` can
+  exercise code paths (helpers via `ApplicationController.helpers`, views via
+  `ApplicationController.render(template:, layout: false)`) without Minitest.
 - The session store uses `CacheStore` (memcached), so the test environment
   needs `config.cache_store = :memory_store` (not `:null_store`) for flash
   and session data to persist across redirects

--- a/Gemfile
+++ b/Gemfile
@@ -173,6 +173,11 @@ group :development do
 end
 
 group :test do
+  # Pin minitest to the 5.x series: minitest 6.x changed run_suite's calling
+  # convention, which is incompatible with the Rails 8.0.x test runner
+  # (railties test_unit/line_filtering) and crashes `bin/rails test`.
+  gem 'minitest', '~> 5.25'
+
   # System testing
   # [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,9 +302,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0924)
     mini_mime (1.1.5)
-    minitest (6.0.3)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     multi_json (1.17.0)
     multipart-post (2.4.1)
@@ -617,6 +615,7 @@ DEPENDENCIES
   jsbundling-rails
   letter_opener_web (~> 2.0)
   lookbook (~> 2.3)
+  minitest (~> 5.25)
   multi_json
   mysql2
   net-ftp

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,3 +1,3 @@
 <%= content_tag :div, id: "bd", style: "clear: both; text-align: center; margin-top: 100px; margin-bottom: 100px;" do -%>
-  <h1>We're sorry but something has gone wrong. We have been notified of this error.</h1>
+  <h1>We're sorry, but something went wrong. Please try again later.</h1>
 <% end -%>

--- a/test/views/errors_view_test.rb
+++ b/test/views/errors_view_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+# Renders the error templates in isolation (no layout, no API calls) so the
+# assertions are deterministic and fast.
+class ErrorsViewTest < ActionView::TestCase
+  test 'internal server error page drops the stale "we have been notified" copy (ncbo#144)' do
+    html = render(template: 'errors/internal_server_error').to_s
+
+    refute_includes html, 'We have been notified',
+                     'airbrake-era "we have been notified" claim should be removed'
+    assert_match(/something went wrong/i, html,
+                 'page should still apologize for the error')
+  end
+end


### PR DESCRIPTION
## Summary

Two related changes, kept as separate commits:

1. **Pin `minitest` to `~> 5.25`** (test-infra prerequisite). `minitest 6.0.3` (resolved transitively under `minitest (>= 5.1)`) changed `run_suite`'s calling convention and is incompatible with the Rails 8.0.x test runner (`railties` `test_unit/line_filtering`): `bin/rails test` crashes with `wrong number of arguments (given 3, expected 1..2)` before any test runs. This pin restores the entire Minitest suite. Documented in `CLAUDE.md`.
2. **Fix the 500 error page wording** (closes #144). The internal server error page claimed *"We have been notified of this error"* — a stale Airbrake-era promise that is no longer accurate (and misleading on the appliance). Replaced with a neutral apology, plus a view-render test.

## Testing

In the dev container: `sudo RAILS_ENV=test bin/rails test test/views/errors_view_test.rb` → green. (The minitest pin is what allows the harness to run at all.)

## Notes

The minitest pin is bundled here because it is a prerequisite for running these — and all other — Minitest tests on Rails 8. It is isolated as its own commit so it can be reviewed or cherry-picked independently.

Closes #144.

_— Posted by Claude Code agent on behalf of @kltm._
