### PR TITLE
Make google-site-verification meta tag configurable (#90)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -431,4 +431,17 @@ module ApplicationHelper
   def analytics_consent?
     cookies[:allow_cookies].present? && cookies[:allow_cookies] == 'true'
   end
+
+  # Google Search Console (Webmaster Tools) site-verification meta tag.
+  # Configurable per environment via settings.yml (google_site_verification)
+  # instead of being hard-coded; omitted entirely on the appliance and when
+  # no token is configured. (closes ncbo#90)
+  def google_site_verification_meta_tag
+    return if Rails.env.appliance?
+
+    token = Rails.configuration.settings.dig(:google_site_verification)
+    return if token.blank?
+
+    tag.meta(name: 'google-site-verification', content: token)
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,10 +7,8 @@
 	<!-- Force IE to use latest rendering engine -->
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
 
-	<% unless Rails.env.appliance? %>
-    <!-- Google Webmaster Tools verifications -->
-  	<meta name="google-site-verification" content="IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks" />
-  <% end %>
+	<!-- Google Webmaster Tools verification (configurable via settings.yml) -->
+	<%= google_site_verification_meta_tag %>
 
 	<%= csrf_meta_tag %>
 

--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -22,9 +22,7 @@
 
   <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-  <% unless appliance_mode %>
-    <meta name="google-site-verification" content="IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks" />
-  <% end %>
+  <%= google_site_verification_meta_tag %>
   <%= csrf_meta_tag %>
   <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
   <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />

--- a/app/views/layouts/partial.html.erb
+++ b/app/views/layouts/partial.html.erb
@@ -1,6 +1,6 @@
 <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-<meta name="google-site-verification" content="IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks" />
+<%= google_site_verification_meta_tag %>
 <%= csrf_meta_tag %>
 <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
 <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />

--- a/app/views/layouts/popup.html.erb
+++ b/app/views/layouts/popup.html.erb
@@ -4,7 +4,7 @@
   <%= render partial: "ga_tracking" %>
   <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
-  <meta name="google-site-verification" content="IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks" />
+  <%= google_site_verification_meta_tag %>
   <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
   <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400' rel='stylesheet' type='text/css'>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,6 +27,7 @@ shared:
 development:
   google_analytics:
     tag_id: null
+  google_site_verification: null
   links:
     cookies: 'https://www.bioontology.org/terms/#use-of-cookies'
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
@@ -38,6 +39,7 @@ development:
 test:
   google_analytics:
     tag_id: null
+  google_site_verification: null
   purl:
     enabled: false
     host: 'stagepurl.bioontology.org'
@@ -46,6 +48,7 @@ test:
 staging:
   google_analytics:
     tag_id: 'G-KF3SKHPEGW'
+  google_site_verification: 'IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks'
   links:
     cookies: 'https://www.bioontology.org/terms/#use-of-cookies'
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
@@ -57,6 +60,7 @@ staging:
 production:
   google_analytics:
     tag_id: 'G-KF3SKHPEGW'
+  google_site_verification: 'IBxfKu6VbYH9atd5OLu2zXVD2ZRWi9SgMKTi8nvw3ks'
   links:
     cookies: 'https://www.bioontology.org/terms/#use-of-cookies'
     release_notes: 'https://github.com/ncbo/bioportal_web_ui/releases'
@@ -68,6 +72,7 @@ production:
 appliance:
   google_analytics:
     tag_id: null
+  google_site_verification: null
   links:
     cookies: 'https://www.bioontology.org/terms/#use-of-cookies'
     release_notes: 'https://www.bioontology.org/wiki/BioPortal_Virtual_Appliance_Release_Notes'

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require 'minitest/mock' # for Object#stub (not loaded by rails/test_help)
+
+class ApplicationHelperTest < ActionView::TestCase
+  tests ApplicationHelper
+
+  # Save/restore the in-memory setting so mutations don't leak across tests.
+  setup do
+    @settings = Rails.configuration.settings
+    @original_token = @settings.google_site_verification
+  end
+
+  teardown do
+    @settings.google_site_verification = @original_token
+  end
+
+  test 'google_site_verification_meta_tag renders the configured token (ncbo#90)' do
+    @settings.google_site_verification = 'TESTTOKEN-123'
+
+    html = google_site_verification_meta_tag.to_s
+    assert_includes html, 'name="google-site-verification"'
+    assert_includes html, 'content="TESTTOKEN-123"'
+  end
+
+  test 'google_site_verification_meta_tag is omitted when no token is configured (ncbo#90)' do
+    @settings.google_site_verification = nil
+
+    assert_nil google_site_verification_meta_tag
+  end
+
+  test 'google_site_verification_meta_tag is omitted on the appliance even when configured (ncbo#90)' do
+    @settings.google_site_verification = 'TESTTOKEN-123'
+
+    Rails.stub(:env, ActiveSupport::StringInquirer.new('appliance')) do
+      assert_nil google_site_verification_meta_tag
+    end
+  end
+end

--- a/test/integration/google_site_verification_test.rb
+++ b/test/integration/google_site_verification_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+# Exercises the full request/response stack: a real page rendered through the
+# `ontology` layout (which renders layouts/_header, talking to the configured
+# staging API) must wire in the google-site-verification meta tag via the
+# helper. Complements the helper unit test with end-to-end coverage. (ncbo#90)
+class GoogleSiteVerificationTest < ActionDispatch::IntegrationTest
+  setup do
+    @settings = Rails.configuration.settings
+    @original_token = @settings.google_site_verification
+  end
+
+  teardown do
+    @settings.google_site_verification = @original_token
+  end
+
+  test 'verification meta tag is rendered into a real page when configured' do
+    @settings.google_site_verification = 'INTEG-TOKEN-XYZ'
+
+    get login_index_url
+    assert_response :success
+    assert_select 'meta[name=?][content=?]', 'google-site-verification', 'INTEG-TOKEN-XYZ'
+  end
+
+  test 'verification meta tag is absent from a real page when not configured' do
+    @settings.google_site_verification = nil
+
+    get login_index_url
+    assert_response :success
+    assert_select 'meta[name="google-site-verification"]', false,
+                  'no verification meta tag should be emitted when unconfigured'
+  end
+end


### PR DESCRIPTION
## Summary

The `google-site-verification` meta tag was hard-coded (the same token) across four layouts. This makes it configurable:

- New per-environment `google_site_verification` key in `config/settings.yml` (token for staging/production; `null` for development/test/appliance), mirroring how `google_analytics` is handled.
- New `ApplicationHelper#google_site_verification_meta_tag` that renders the tag, omitting it on the appliance and when no token is configured.
- The `_header`, `angular`, `partial`, and `popup` layouts now call the helper instead of hard-coding the tag (incidentally giving `partial`/`popup` the same appliance suppression the other two already had).

## Testing

- Helper unit test: configured / blank / appliance branches.
- Full-stack integration test: tag present when configured / absent when not, in a real page rendered through the layout.

Both green in the dev container.

## Dependency

CI here depends on the `minitest` 5.x pin in #512 (the Rails 8 Minitest harness is otherwise broken and `bin/rails test` crashes). Once #512 lands, this PR's tests run clean; I'll rebase on `master` afterward.

Closes #90.

_— Posted by Claude Code agent on behalf of @kltm._
