### PR TITLE
Replace annotator filter popups with DataTables ColumnControl

### DIFF
--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -119,281 +119,6 @@ function get_annotations() {
   });
 } // get_annotations
 
-var displayFilteredColumnNames = function() {
-  "use strict";
-  var column_names = [];
-  var header_text;
-  jQuery(".bp_popup_list input:checked").closest("th").each(function() {
-    // DataTables 2.x wraps the header content in a .dt-column-title span; read the
-    // column label from there (falling back to the th itself for older markup) so
-    // we don't pick up the filter popup's contents.
-    var titleEl = this.querySelector(".dt-column-title") || this;
-    header_text = titleEl.childNodes[0].textContent.trim();
-    column_names.push(header_text);
-  });
-  jQuery("#filter_names").html(column_names.join(", "));
-  if (column_names.length > 0) {
-    jQuery("#filter_list").show();
-  } else {
-    jQuery("#filter_list").hide();
-  }
-};
-
-function createFilterCheckboxes(filter_items, checkbox_class, checkbox_location) {
-  "use strict";
-  var for_sort = [],
-    sorted = [];
-
-  // Sort ontologies by number of results
-  jQuery.each(filter_items, function(k, v) {
-    for_sort.push({
-      label: k + " (" + v + ")",
-      count: v,
-      value: k,
-      value_encoded: encodeURIComponent(k)
-    });
-  });
-  for_sort.sort(function(a, b) {
-    return jQuery.trim(a.label) > jQuery.trim(b.label)
-  });
-
-  // Create checkboxes for ontology filter
-  jQuery.each(for_sort, function() {
-    var checkbox = jQuery("<input/>").attr("class", checkbox_class).attr("type", "checkbox").attr("value", this.value).attr("id", checkbox_class + this.value_encoded);
-    var label = jQuery("<label/>").attr("for", checkbox_class + this.value_encoded).html(" " + this.label);
-    sorted.push(jQuery("<span/>").append(checkbox).append(label).html());
-  });
-  jQuery("#" + checkbox_location).html(sorted.join("<br/>"));
-}
-
-var filter_ontologies = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_ontologies").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_ontology_checkboxes").bind("click", function(e) {
-      filter_ontologies.filterOntology(e)
-    });
-    jQuery("#ontology_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterOntology: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_ontology_checkboxes:checked").each(function() {
-      search_regex.push(jQuery(this).val());
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.ontologies).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.ontologies).search(search_regex.join("|"), true, false).draw();
-    }
-  }
-};
-
-var filter_classes = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_classes").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_classes_checkboxes").bind("click", function(e) {
-      filter_classes.filterClasses(e)
-    });
-    jQuery("#classes_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterClasses: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_classes_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.classes).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.classes).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var filter_matched_ontologies = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_matched_ontologies").bind("click", function(e) {
-      bp_popup_init(e);
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_matched_ontology_checkboxes").bind("click", function(e) {
-      filter_matched_ontologies.filter(e);
-    });
-    jQuery("#ontology_matched_filter_list").click(function(e) {
-      e.stopPropagation();
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filter: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_matched_ontology_checkboxes:checked").each(function() {
-      search_regex.push(jQuery(this).val());
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.matched_ontologies).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.matched_ontologies).search(search_regex.join("|"), true, false).draw();
-    }
-  }
-};
-
-var filter_matched_classes = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_matched_classes").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_matched_classes_checkboxes").bind("click", function(e) {
-      filter_matched_classes.filter(e)
-    });
-    jQuery("#matched_classes_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filter: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_matched_classes_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.matched_classes).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.matched_classes).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var filter_match_type = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_match_type").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_match_type_checkboxes").bind("click", function(e) {
-      filter_match_type.filterMatchType(e)
-    });
-    jQuery("#match_type_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterMatchType: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_match_type_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.types).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.types).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var removeFilters = function() {
-  "use strict";
-  jQuery(".filter_ontology_checkboxes").attr("checked", false);
-  jQuery(".filter_classes_checkboxes").attr("checked", false);
-  jQuery(".filter_match_type_checkboxes").attr("checked", false);
-  jQuery(".filter_matched_classes_checkboxes").attr("checked", false);
-  jQuery(".filter_matched_ontologies_checkboxes").attr("checked", false);
-  annotationsTable
-    .columns([BP_COLUMNS.classes, BP_COLUMNS.ontologies, BP_COLUMNS.types,
-              BP_COLUMNS.matched_classes, BP_COLUMNS.matched_ontologies])
-    .search("")
-    .draw();
-  jQuery("#filter_list").hide();
-};
-
 function annotatorFormatLink(param_string, format) {
   "use strict";
   // TODO: Check whether 'text' and 'tabDelimited' could work.
@@ -446,11 +171,7 @@ jQuery(document).ready(function() {
   jQuery("#insert_text_link").click(insertSampleText);
   // The annotations table is initialized by the annotator-table Stimulus
   // controller, which assigns the DataTables API instance to annotationsTable.
-  filter_ontologies.init();
-  filter_classes.init();
-  filter_match_type.init();
-  filter_matched_ontologies.init();
-  filter_matched_classes.init();
+  // Column filtering is handled by the DataTables ColumnControl extension.
 
   jQuery("#annotations_container").hide();
 }); // doc ready
@@ -608,48 +329,19 @@ function get_annotation_rows_from_raw(annotation, params) {
 
 function update_annotations_table(rowsArray) {
   "use strict";
-  var ontologies = {},
-    classes = {},
-    match_types = {},
-    matched_ontologies = {},
-    matched_classes = {},
+  var match_types = {},
     context_count = 0;
 
   jQuery(rowsArray).each(function() {
     // [ cls_link, ont_link, match_type, semantic_types, text_markup, cls_link, ont_link ];
     var row = this,
-      cls_link = row[0],
-      ont_link = row[1],
-      match_type = row[2], // direct, ancestors, mapping
-      //semantic_type = row[3],
-      //match_text = row[4],
-      match_cls_link = row[5],
-      match_ont_link = row[6];
-    // Extract labels from links (using non-greedy regex).
-    var cls_label = cls_link.replace(/^<a.*?>/, '').replace('</a>', '').toLowerCase(),
-      ont_label = ont_link.replace(/^<a.*?>/, '').replace('</a>', ''),
-      match_cls_label = match_cls_link.replace(/^<a.*?>/, '').replace('</a>', '').toLowerCase(),
-      match_ont_label = match_ont_link.replace(/^<a.*?>/, '').replace('</a>', '');
-
-    // TODO: Gather sem types for display
-    //    var semantic_types = [];
-    //    jQuery.each(annotation.concept.semantic_types, function () {
-    //      semantic_types.push(this.description);
-    //    });
+      match_type = row[2]; // direct, ancestors, mapping
 
     // Keep track of contexts. If there are none (IE when using mallet), hide the column
     if (row[4] !== "") context_count++;
 
-    // Keep track of how many results are associated with each ontology
-    ontologies[ont_label] = (ont_label in ontologies) ? ontologies[ont_label] + 1 : 1;
-    // Keep track of how many results are associated with each class
-    classes[cls_label] = (cls_label in classes) ? classes[cls_label] + 1 : 1;
     // Keep track of match types
     match_types[match_type] = (match_type in match_types) ? match_types[match_type] + 1 : 1;
-    // Keep track of matched classes
-    matched_classes[match_cls_label] = (match_cls_label in matched_classes) ? matched_classes[match_cls_label] + 1 : 1;
-    // Keep track of matched ontologies
-    matched_ontologies[match_ont_label] = (match_ont_label in matched_ontologies) ? matched_ontologies[match_ont_label] + 1 : 1;
   });
 
   // Add result counts
@@ -664,28 +356,19 @@ function update_annotations_table(rowsArray) {
   jQuery("#result_counts").append("&nbsp;/&nbsp;" + "mapping " + count_span + mapping_count + "</span>");
   jQuery("#result_counts").append(")");
 
-  // Add checkboxes to filters
-  createFilterCheckboxes(ontologies, "filter_ontology_checkboxes", "ontology_filter_list");
-  createFilterCheckboxes(classes, "filter_classes_checkboxes", "classes_filter_list");
-  createFilterCheckboxes(match_types, "filter_match_type_checkboxes", "match_type_filter_list");
-  createFilterCheckboxes(matched_ontologies, "filter_matched_ontology_checkboxes", "matched_ontology_filter_list");
-  createFilterCheckboxes(matched_classes, "filter_matched_classes_checkboxes", "matched_classes_filter_list");
-
-  // Reset table (clear rows and any sorting)
-  annotationsTable.clear().order([]).draw();
-  removeFilters();
-
-  // Need to re-init because we're not using "live" because of propagation issues
-  filter_ontologies.init();
-  filter_classes.init();
-  filter_match_type.init();
-  filter_matched_ontologies.init();
-  filter_matched_classes.init();
+  // Reset table (clear rows, sorting, and any ColumnControl column filters)
+  annotationsTable.clear().order([]);
+  annotationsTable.columns().columnControl.searchClear();
+  annotationsTable.draw();
 
   // Add data
   if (rowsArray.length > 0) {
     annotationsTable.rows.add(rowsArray).draw();
   }
+
+  // Rebuild the searchList filter options from the new data (they are only
+  // refreshed automatically for Ajax-loaded tables)
+  annotationsTable.columns().columnControl.searchList('refresh');
 
   // Hide columns as necessary
   if (context_count == 0) {

--- a/app/assets/javascripts/bp_annotator.js
+++ b/app/assets/javascripts/bp_annotator.js
@@ -344,18 +344,6 @@ function update_annotations_table(rowsArray) {
     match_types[match_type] = (match_type in match_types) ? match_types[match_type] + 1 : 1;
   });
 
-  // Add result counts
-  var count_span = '<span class="result_count">'
-  jQuery("#result_counts").html("total results " + count_span + rowsArray.length + "</span>&nbsp;");
-  var direct_count = ("direct" in match_types) ? match_types["direct"] : 0,
-    ancestor_count = ("ancestor" in match_types) ? match_types["ancestor"] : 0,
-    mapping_count = ("mapping" in match_types) ? match_types["mapping"] : 0;
-  jQuery("#result_counts").append("(");
-  jQuery("#result_counts").append("direct " + count_span + direct_count + "</span>");
-  jQuery("#result_counts").append("&nbsp;/&nbsp;" + "ancestor " + count_span + ancestor_count + "</span>");
-  jQuery("#result_counts").append("&nbsp;/&nbsp;" + "mapping " + count_span + mapping_count + "</span>");
-  jQuery("#result_counts").append(")");
-
   // Reset table (clear rows, sorting, and any ColumnControl column filters)
   annotationsTable.clear().order([]);
   annotationsTable.columns().columnControl.searchClear();

--- a/app/assets/javascripts/bp_annotatorplus.js
+++ b/app/assets/javascripts/bp_annotatorplus.js
@@ -160,281 +160,6 @@ function get_annotations() {
   });
 } // get_annotations
 
-var displayFilteredColumnNames = function() {
-  "use strict";
-  var column_names = [];
-  var header_text;
-  jQuery(".bp_popup_list input:checked").closest("th").each(function() {
-    // DataTables 2.x wraps the header content in a .dt-column-title span; read the
-    // column label from there (falling back to the th itself for older markup) so
-    // we don't pick up the filter popup's contents.
-    var titleEl = this.querySelector(".dt-column-title") || this;
-    header_text = titleEl.childNodes[0].textContent.trim();
-    column_names.push(header_text);
-  });
-  jQuery("#filter_names").html(column_names.join(", "));
-  if (column_names.length > 0) {
-    jQuery("#filter_list").show();
-  } else {
-    jQuery("#filter_list").hide();
-  }
-};
-
-function createFilterCheckboxes(filter_items, checkbox_class, checkbox_location) {
-  "use strict";
-  var for_sort = [],
-    sorted = [];
-
-  // Sort ontologies by number of results
-  jQuery.each(filter_items, function(k, v) {
-    for_sort.push({
-      label: k + " (" + v + ")",
-      count: v,
-      value: k,
-      value_encoded: encodeURIComponent(k)
-    });
-  });
-  for_sort.sort(function(a, b) {
-    return jQuery.trim(a.label) > jQuery.trim(b.label)
-  });
-
-  // Create checkboxes for ontology filter
-  jQuery.each(for_sort, function() {
-    var checkbox = jQuery("<input/>").attr("class", checkbox_class).attr("type", "checkbox").attr("value", this.value).attr("id", checkbox_class + this.value_encoded);
-    var label = jQuery("<label/>").attr("for", checkbox_class + this.value_encoded).html(" " + this.label);
-    sorted.push(jQuery("<span/>").append(checkbox).append(label).html());
-  });
-  jQuery("#" + checkbox_location).html(sorted.join("<br/>"));
-}
-
-var filter_ontologies = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_ontologies").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_ontology_checkboxes").bind("click", function(e) {
-      filter_ontologies.filterOntology(e)
-    });
-    jQuery("#ontology_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterOntology: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_ontology_checkboxes:checked").each(function() {
-      search_regex.push(jQuery(this).val());
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.ontologies).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.ontologies).search(search_regex.join("|"), true, false).draw();
-    }
-  }
-};
-
-var filter_classes = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_classes").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_classes_checkboxes").bind("click", function(e) {
-      filter_classes.filterClasses(e)
-    });
-    jQuery("#classes_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterClasses: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_classes_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.classes).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.classes).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var filter_matched_ontologies = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_matched_ontologies").bind("click", function(e) {
-      bp_popup_init(e);
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_matched_ontology_checkboxes").bind("click", function(e) {
-      filter_matched_ontologies.filter(e);
-    });
-    jQuery("#ontology_matched_filter_list").click(function(e) {
-      e.stopPropagation();
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filter: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_matched_ontology_checkboxes:checked").each(function() {
-      search_regex.push(jQuery(this).val());
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.matched_ontologies).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.matched_ontologies).search(search_regex.join("|"), true, false).draw();
-    }
-  }
-};
-
-var filter_matched_classes = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_matched_classes").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_matched_classes_checkboxes").bind("click", function(e) {
-      filter_matched_classes.filter(e)
-    });
-    jQuery("#matched_classes_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filter: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_matched_classes_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.matched_classes).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.matched_classes).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var filter_match_type = {
-  init: function() {
-    "use strict";
-    jQuery("#filter_match_type").bind("click", function(e) {
-      bp_popup_init(e)
-    });
-    // Need to use bind to avoid "live" propogation issues
-    jQuery(".filter_match_type_checkboxes").bind("click", function(e) {
-      filter_match_type.filterMatchType(e)
-    });
-    jQuery("#match_type_filter_list").click(function(e) {
-      e.stopPropagation()
-    });
-    this.cleanup();
-  },
-
-  cleanup: function() {
-    "use strict";
-    jQuery("html").click(bp_popup_cleanup);
-    jQuery(document).keyup(function(e) {
-      if (e.keyCode == 27) {
-        bp_popup_cleanup();
-      } // esc
-    });
-  },
-
-  filterMatchType: function(e) {
-    "use strict";
-    e.stopPropagation();
-    var search_regex = [];
-    jQuery(".filter_match_type_checkboxes:checked").each(function() {
-      // Escape characters used in regex
-      search_regex.push(jQuery(this).val().replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"));
-    });
-    displayFilteredColumnNames();
-    if (search_regex.length === 0) {
-      annotationsTable.column(BP_COLUMNS.types).search("").draw();
-    } else {
-      annotationsTable.column(BP_COLUMNS.types).search("^" + search_regex.join("(?!.)|^") + "(?!.)", true, false).draw();
-    }
-  }
-};
-
-var removeFilters = function() {
-  "use strict";
-  jQuery(".filter_ontology_checkboxes").attr("checked", false);
-  jQuery(".filter_classes_checkboxes").attr("checked", false);
-  jQuery(".filter_match_type_checkboxes").attr("checked", false);
-  jQuery(".filter_matched_classes_checkboxes").attr("checked", false);
-  jQuery(".filter_matched_ontologies_checkboxes").attr("checked", false);
-  annotationsTable
-    .columns([BP_COLUMNS.classes, BP_COLUMNS.ontologies, BP_COLUMNS.types,
-              BP_COLUMNS.matched_classes, BP_COLUMNS.matched_ontologies])
-    .search("")
-    .draw();
-  jQuery("#filter_list").hide();
-};
-
 function annotatorFormatLink(param_string, format) {
   "use strict";
   // TODO: Check whether 'text' and 'tabDelimited' could work.
@@ -507,11 +232,7 @@ jQuery(document).ready(function() {
   
   // The annotations table is initialized by the annotator-plus-table Stimulus
   // controller, which assigns the DataTables API instance to annotationsTable.
-  filter_ontologies.init();
-  filter_classes.init();
-  filter_match_type.init();
-  filter_matched_ontologies.init();
-  filter_matched_classes.init();
+  // Column filtering is handled by the DataTables ColumnControl extension.
 
   jQuery("#annotations_container").hide();
 }); // doc ready
@@ -687,48 +408,19 @@ function get_annotation_rows_from_raw(annotation, params) {
 
 function update_annotations_table(rowsArray) {
   "use strict";
-  var ontologies = {},
-    classes = {},
-    match_types = {},
-    matched_ontologies = {},
-    matched_classes = {},
+  var match_types = {},
     context_count = 0;
 
   jQuery(rowsArray).each(function() {
     // [ cls_link, ont_link, match_type, semantic_types, text_markup, cls_link, ont_link ];
     var row = this,
-      cls_link = row[0],
-      ont_link = row[1],
-      match_type = row[2], // direct, ancestors, mapping
-      //semantic_type = row[3],
-      //match_text = row[4],
-      match_cls_link = row[5],
-      match_ont_link = row[6];
-    // Extract labels from links (using non-greedy regex).
-    var cls_label = cls_link.replace(/^<a.*?>/, '').replace('</a>', '').toLowerCase(),
-      ont_label = ont_link.replace(/^<a.*?>/, '').replace('</a>', ''),
-      match_cls_label = match_cls_link.replace(/^<a.*?>/, '').replace('</a>', '').toLowerCase(),
-      match_ont_label = match_ont_link.replace(/^<a.*?>/, '').replace('</a>', '');
-
-    // TODO: Gather sem types for display
-    //    var semantic_types = [];
-    //    jQuery.each(annotation.concept.semantic_types, function () {
-    //      semantic_types.push(this.description);
-    //    });
+      match_type = row[2]; // direct, ancestors, mapping
 
     // Keep track of contexts. If there are none (IE when using mallet), hide the column
     if (row[4] !== "") context_count++;
 
-    // Keep track of how many results are associated with each ontology
-    ontologies[ont_label] = (ont_label in ontologies) ? ontologies[ont_label] + 1 : 1;
-    // Keep track of how many results are associated with each class
-    classes[cls_label] = (cls_label in classes) ? classes[cls_label] + 1 : 1;
     // Keep track of match types
     match_types[match_type] = (match_type in match_types) ? match_types[match_type] + 1 : 1;
-    // Keep track of matched classes
-    matched_classes[match_cls_label] = (match_cls_label in matched_classes) ? matched_classes[match_cls_label] + 1 : 1;
-    // Keep track of matched ontologies
-    matched_ontologies[match_ont_label] = (match_ont_label in matched_ontologies) ? matched_ontologies[match_ont_label] + 1 : 1;
   });
 
   // Add result counts
@@ -743,28 +435,19 @@ function update_annotations_table(rowsArray) {
   jQuery("#result_counts").append("&nbsp;/&nbsp;" + "mapping " + count_span + mapping_count + "</span>");
   jQuery("#result_counts").append(")");
 
-  // Add checkboxes to filters
-  createFilterCheckboxes(ontologies, "filter_ontology_checkboxes", "ontology_filter_list");
-  createFilterCheckboxes(classes, "filter_classes_checkboxes", "classes_filter_list");
-  createFilterCheckboxes(match_types, "filter_match_type_checkboxes", "match_type_filter_list");
-  createFilterCheckboxes(matched_ontologies, "filter_matched_ontology_checkboxes", "matched_ontology_filter_list");
-  createFilterCheckboxes(matched_classes, "filter_matched_classes_checkboxes", "matched_classes_filter_list");
-
-  // Reset table
-  annotationsTable.clear().order([]).draw();
-  removeFilters();
-
-  // Need to re-init because we're not using "live" because of propagation issues
-  filter_ontologies.init();
-  filter_classes.init();
-  filter_match_type.init();
-  filter_matched_ontologies.init();
-  filter_matched_classes.init();
+  // Reset table (clear rows, sorting, and any ColumnControl column filters)
+  annotationsTable.clear().order([]);
+  annotationsTable.columns().columnControl.searchClear();
+  annotationsTable.draw();
 
   // Add data
   if (rowsArray.length > 0) {
     annotationsTable.rows.add(rowsArray).draw();
   }
+
+  // Rebuild the searchList filter options from the new data (they are only
+  // refreshed automatically for Ajax-loaded tables)
+  annotationsTable.columns().columnControl.searchList('refresh');
 
   // Hide columns as necessary
   if (context_count == 0) {

--- a/app/assets/javascripts/bp_annotatorplus.js
+++ b/app/assets/javascripts/bp_annotatorplus.js
@@ -423,18 +423,6 @@ function update_annotations_table(rowsArray) {
     match_types[match_type] = (match_type in match_types) ? match_types[match_type] + 1 : 1;
   });
 
-  // Add result counts
-  var count_span = '<span class="result_count">'
-  jQuery("#result_counts").html("total results " + count_span + rowsArray.length + "</span>&nbsp;");
-  var direct_count = ("direct" in match_types) ? match_types["direct"] : 0,
-    ancestor_count = ("ancestor" in match_types) ? match_types["ancestor"] : 0,
-    mapping_count = ("mapping" in match_types) ? match_types["mapping"] : 0;
-  jQuery("#result_counts").append("(");
-  jQuery("#result_counts").append("direct " + count_span + direct_count + "</span>");
-  jQuery("#result_counts").append("&nbsp;/&nbsp;" + "ancestor " + count_span + ancestor_count + "</span>");
-  jQuery("#result_counts").append("&nbsp;/&nbsp;" + "mapping " + count_span + mapping_count + "</span>");
-  jQuery("#result_counts").append(")");
-
   // Reset table (clear rows, sorting, and any ColumnControl column filters)
   annotationsTable.clear().order([]);
   annotationsTable.columns().columnControl.searchClear();

--- a/app/assets/stylesheets/annotator.scss
+++ b/app/assets/stylesheets/annotator.scss
@@ -2,14 +2,6 @@ select#semantic_types + .chosen-container {
   display: block;
 }
 
-div#annotations_filter, div#annotations_info {
-  display: none;
-}
-
-.result_count {
-  font-weight: bold;
-}
-
 #annotations th {
 	padding-right: 6px;
 }
@@ -20,15 +12,9 @@ div#annotations_filter, div#annotations_info {
 }
 
 #annotations_container {
-  display: none; 
-  margin-top: 10px; 
+  display: none;
+  margin-top: 10px;
   margin-bottom: 25px;
-}
-
-#annotations_container #result_counts {
-  float: right; 
-  font-style: oblique; 
-  color: gray;
 }
 
 /* AnnotatorPlus */

--- a/app/assets/stylesheets/annotator.scss
+++ b/app/assets/stylesheets/annotator.scss
@@ -14,10 +14,6 @@ div#annotations_filter, div#annotations_info {
 	padding-right: 6px;
 }
 
-#annotations span[class="popup_container"] {
-  padding-left: 1.7em;
-}
-
 #annotator_parameters {
   color: gray; 
   font-weight: bold;

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -14,6 +14,7 @@
 @use 'tippy.js/dist/tippy';
 @use 'tippy.js/themes/light-border';
 @use 'datatables.net-bs5/css/dataTables.bootstrap5';
+@use 'datatables.net-columncontrol-bs5/css/columnControl.bootstrap5';
 
 // BioPortal
 @use 'account';

--- a/app/javascript/application_esbuild.js
+++ b/app/javascript/application_esbuild.js
@@ -2,6 +2,7 @@
 
 import { Turbo } from '@hotwired/turbo-rails';
 import DataTable from 'datatables.net-bs5';
+import 'datatables.net-columncontrol-bs5';
 import './controllers';
 import './component_controllers';
 import * as bootstrap from 'bootstrap';

--- a/app/javascript/controllers/annotator_plus_table_controller.js
+++ b/app/javascript/controllers/annotator_plus_table_controller.js
@@ -9,13 +9,23 @@ export default class extends Controller {
   static targets = ['table'];
 
   tableTargetConnected(table) {
+    // Filterable columns get a ColumnControl dropdown (hamburger icon) holding a
+    // searchList of the column's values. Cells contain HTML links, so the list
+    // labels use the 'filter' orthogonal data (tags stripped) instead of the
+    // default 'display'.
+    const searchListDropdown = ['order', [{ extend: 'searchList', orthogonal: 'filter' }]];
+
     window.annotationsTable = new DataTable(table, {
       paging: false,
       autoWidth: false,
       order: [],
+      // Ordering is handled by the ColumnControl 'order' buttons, so DataTables'
+      // own header click handler and sort indicators are turned off.
+      ordering: { indicators: false, handler: false },
+      columnControl: ['order'],
       // Suppress DataTables' built-in chrome (global search box, info line, etc.).
-      // The annotator has its own per-column filter popups and #result_counts;
-      // searching stays enabled so those column filters keep working.
+      // The annotator has its own #result_counts; searching stays enabled so the
+      // ColumnControl column filters keep working.
       layout: {
         topStart: null,
         topEnd: null,
@@ -24,13 +34,13 @@ export default class extends Controller {
       },
       language: { zeroRecords: 'No annotations found' },
       columns: [
-        { width: '15%' }, // Class
-        { width: '15%' }, // Ontology
-        { width: '5%' }, // Type
+        { width: '15%', columnControl: searchListDropdown }, // Class
+        { width: '15%', columnControl: searchListDropdown }, // Ontology
+        { width: '5%', columnControl: searchListDropdown }, // Type
         { width: '5%', visible: false }, // Semantic types (hidden by default)
         { width: '20%' }, // Context
-        { width: '15%' }, // Matched class
-        { width: '15%' }, // Matched ontology
+        { width: '15%', columnControl: searchListDropdown }, // Matched class
+        { width: '15%', columnControl: searchListDropdown }, // Matched ontology
         { width: '5%', visible: false }, // Score
         { width: '5%', visible: false }, // Negation
         { width: '5%', visible: false }, // Experiencer

--- a/app/javascript/controllers/annotator_plus_table_controller.js
+++ b/app/javascript/controllers/annotator_plus_table_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import DataTable from 'datatables.net-bs5';
+import { buildAnnotationsSummary } from '../utils/annotations_info';
 
 // Connects to data-controller="annotator-plus-table" on the static #annotations_container.
 // Exposes the DataTables API instance as `window.annotationsTable` for the legacy
@@ -15,22 +16,27 @@ export default class extends Controller {
     // default 'display'.
     const searchListDropdown = ['order', [{ extend: 'searchList', orthogonal: 'filter' }]];
 
-    window.annotationsTable = new DataTable(table, {
-      paging: false,
+    const annotationsTable = new DataTable(table, {
+      paging: true,
+      pageLength: 25,
       autoWidth: false,
       order: [],
       // Ordering is handled by the ColumnControl 'order' buttons, so DataTables'
       // own header click handler and sort indicators are turned off.
       ordering: { indicators: false, handler: false },
       columnControl: ['order'],
-      // Suppress DataTables' built-in chrome (global search box, info line, etc.).
-      // The annotator has its own #result_counts; searching stays enabled so the
-      // ColumnControl column filters keep working.
+      // A custom grand-total summary lives in the top-start `div` feature
+      // (replacing the old #result_counts div); it's populated on each draw
+      // below. The default per-page "Showing X to Y of Z" info sits bottom-start
+      // (kept as the sole `info` feature so it retains the aria-live/status
+      // semantics). Page-length selector sits top-end, pagination bottom-end. The
+      // global search box stays off — the ColumnControl column filters cover
+      // per-column searching.
       layout: {
-        topStart: null,
-        topEnd: null,
-        bottomStart: null,
-        bottomEnd: null,
+        topStart: { div: { id: 'annotations_summary', className: 'text-muted' } },
+        topEnd: 'pageLength',
+        bottomStart: 'info',
+        bottomEnd: 'paging',
       },
       language: { zeroRecords: 'No annotations found' },
       columns: [
@@ -47,5 +53,17 @@ export default class extends Controller {
         { width: '5%', visible: false }, // Temporality
       ],
     });
+
+    // The top-start `div` feature is static, so populate it ourselves. "Total
+    // results" is a grand total (ignores column filters), so recomputing on each
+    // draw is cheap and keeps it correct after row and column-visibility changes.
+    annotationsTable.on('draw', () => {
+      const summaryEl = this.element.querySelector('#annotations_summary');
+      if (summaryEl) {
+        summaryEl.textContent = buildAnnotationsSummary(annotationsTable);
+      }
+    });
+
+    window.annotationsTable = annotationsTable;
   }
 }

--- a/app/javascript/controllers/annotator_table_controller.js
+++ b/app/javascript/controllers/annotator_table_controller.js
@@ -9,13 +9,23 @@ export default class extends Controller {
   static targets = ['table'];
 
   tableTargetConnected(table) {
+    // Filterable columns get a ColumnControl dropdown (hamburger icon) holding a
+    // searchList of the column's values. Cells contain HTML links, so the list
+    // labels use the 'filter' orthogonal data (tags stripped) instead of the
+    // default 'display'.
+    const searchListDropdown = ['order', [{ extend: 'searchList', orthogonal: 'filter' }]];
+
     window.annotationsTable = new DataTable(table, {
       paging: false,
       autoWidth: false,
       order: [],
+      // Ordering is handled by the ColumnControl 'order' buttons, so DataTables'
+      // own header click handler and sort indicators are turned off.
+      ordering: { indicators: false, handler: false },
+      columnControl: ['order'],
       // Suppress DataTables' built-in chrome (global search box, info line, etc.).
-      // The annotator has its own per-column filter popups and #result_counts;
-      // searching stays enabled so those column filters keep working.
+      // The annotator has its own #result_counts; searching stays enabled so the
+      // ColumnControl column filters keep working.
       layout: {
         topStart: null,
         topEnd: null,
@@ -24,13 +34,13 @@ export default class extends Controller {
       },
       language: { zeroRecords: 'No annotations found' },
       columns: [
-        { width: '15%' },
-        { width: '15%' },
-        { width: '5%' },
+        { width: '15%', columnControl: searchListDropdown },
+        { width: '15%', columnControl: searchListDropdown },
+        { width: '5%', columnControl: searchListDropdown },
         { width: '5%', visible: false },
         { width: '30%' },
-        { width: '15%' },
-        { width: '15%' },
+        { width: '15%', columnControl: searchListDropdown },
+        { width: '15%', columnControl: searchListDropdown },
       ],
     });
   }

--- a/app/javascript/controllers/annotator_table_controller.js
+++ b/app/javascript/controllers/annotator_table_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import DataTable from 'datatables.net-bs5';
+import { buildAnnotationsSummary } from '../utils/annotations_info';
 
 // Connects to data-controller="annotator-table" on the static #annotations_container.
 // Exposes the DataTables API instance as `window.annotationsTable` for the legacy
@@ -15,22 +16,27 @@ export default class extends Controller {
     // default 'display'.
     const searchListDropdown = ['order', [{ extend: 'searchList', orthogonal: 'filter' }]];
 
-    window.annotationsTable = new DataTable(table, {
-      paging: false,
+    const annotationsTable = new DataTable(table, {
+      paging: true,
+      pageLength: 25,
       autoWidth: false,
       order: [],
       // Ordering is handled by the ColumnControl 'order' buttons, so DataTables'
       // own header click handler and sort indicators are turned off.
       ordering: { indicators: false, handler: false },
       columnControl: ['order'],
-      // Suppress DataTables' built-in chrome (global search box, info line, etc.).
-      // The annotator has its own #result_counts; searching stays enabled so the
-      // ColumnControl column filters keep working.
+      // A custom grand-total summary lives in the top-start `div` feature
+      // (replacing the old #result_counts div); it's populated on each draw
+      // below. The default per-page "Showing X to Y of Z" info sits bottom-start
+      // (kept as the sole `info` feature so it retains the aria-live/status
+      // semantics). Page-length selector sits top-end, pagination bottom-end. The
+      // global search box stays off — the ColumnControl column filters cover
+      // per-column searching.
       layout: {
-        topStart: null,
-        topEnd: null,
-        bottomStart: null,
-        bottomEnd: null,
+        topStart: { div: { id: 'annotations_summary', className: 'text-muted' } },
+        topEnd: 'pageLength',
+        bottomStart: 'info',
+        bottomEnd: 'paging',
       },
       language: { zeroRecords: 'No annotations found' },
       columns: [
@@ -43,5 +49,17 @@ export default class extends Controller {
         { width: '15%', columnControl: searchListDropdown },
       ],
     });
+
+    // The top-start `div` feature is static, so populate it ourselves. "Total
+    // results" is a grand total (ignores column filters), so recomputing on each
+    // draw is cheap and keeps it correct after row and column-visibility changes.
+    annotationsTable.on('draw', () => {
+      const summaryEl = this.element.querySelector('#annotations_summary');
+      if (summaryEl) {
+        summaryEl.textContent = buildAnnotationsSummary(annotationsTable);
+      }
+    });
+
+    window.annotationsTable = annotationsTable;
   }
 }

--- a/app/javascript/utils/annotations_info.js
+++ b/app/javascript/utils/annotations_info.js
@@ -1,0 +1,28 @@
+// Builds the grand-total summary text shown in the annotator results tables'
+// top-start `div` layout feature, replacing the old #result_counts div. Column
+// index 2 (Type) holds 'direct' / 'ancestor' / 'mapping' / '' for each row. The
+// total and breakdown always reflect the full result set ({ search: 'none' }),
+// regardless of any ColumnControl column filters; the per-page "Showing X to Y
+// of Z" summary is handled separately by the default `info` control in the
+// bottom-start slot.
+//
+// The `div` feature is static, so callers set this string on the table's `draw`
+// event (see the annotator table controllers).
+export function buildAnnotationsSummary(api) {
+  const counts = { direct: 0, ancestor: 0, mapping: 0 };
+
+  api
+    .column(2, { search: 'none' })
+    .data()
+    .each((type) => {
+      if (type in counts) {
+        counts[type] += 1;
+      }
+    });
+
+  const total = api.rows({ search: 'none' }).count();
+
+  return (
+    `Total results: ${total} ` + `(direct ${counts.direct} / ancestor ${counts.ancestor} / mapping ${counts.mapping})`
+  );
+}

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -69,7 +69,6 @@
 %div.row
   %div.col
     #annotations_container{'data-controller': 'annotator-table'}
-      #result_counts
       %h2{:style => "margin-bottom: 0;"}
         Annotations
       #results_error{:style => "color: red; margin-bottom: 7px;"}

--- a/app/views/annotator/index.html.haml
+++ b/app/views/annotator/index.html.haml
@@ -72,46 +72,17 @@
       #result_counts
       %h2{:style => "margin-bottom: 0;"}
         Annotations
-      #filter_list{:style => "font-size: 9pt; color: gray; display: none; clear: both; margin: 0 0 5px"}
-        %span#filter_title> Results are filtered by:
-        \&nbsp;
-        %span#filter_names
       #results_error{:style => "color: red; margin-bottom: 7px;"}
       %table#annotations.table.table-striped{:style => "min-width: 700px; width: 100%;", 'data-annotator-table-target': 'table'}
         %thead
           %tr
-            %th
-              Class
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_classes.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#classes_filter_list.bp_popup_list
-            %th
-              Ontology
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_ontologies.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#ontology_filter_list.bp_popup_list
-            %th{class: "match_type"}
-              Type
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_match_type.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#match_type_filter_list.bp_popup_list
+            %th Class
+            %th Ontology
+            %th{class: "match_type"} Type
             %th UMLS Sem Type
             %th{class: "match_context"} Context
-            %th
-              Matched Class
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_matched_classes.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#matched_classes_filter_list.bp_popup_list
-            %th
-              Matched Ontology
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_matched_ontologies.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#matched_ontology_filter_list.bp_popup_list
+            %th Matched Class
+            %th Matched Ontology
         %tbody
       #download_links.mt-4
         %span.fw-bold Format results as:

--- a/app/views/annotatorplus/index.html.haml
+++ b/app/views/annotatorplus/index.html.haml
@@ -127,46 +127,17 @@
     #annotations_container{'data-controller': 'annotator-plus-table'}
       #result_counts
       %h4 Annotations
-      #filter_list{:style => "font-size: 9pt; color: gray; display: none; clear: both; margin: 0 0 5px"}
-        %span#filter_title> Results are filtered by:
-        \&nbsp;
-        %span#filter_names
       #results_error{:style => "color: red; margin-bottom: 7px;"}
       %table#annotations.table.table-striped{:style => "min-width: 700px; width: 100%;", 'data-annotator-plus-table-target': 'table'}
         %thead
           %tr
-            %th
-              Class
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_classes.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#classes_filter_list.bp_popup_list
-            %th
-              Ontology
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_ontologies.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#ontology_filter_list.bp_popup_list
-            %th{class: "match_type"}
-              Type
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_match_type.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#match_type_filter_list.bp_popup_list
+            %th Class
+            %th Ontology
+            %th{class: "match_type"} Type
             %th UMLS Sem Type
             %th{class: "match_context"} Context
-            %th
-              Matched Class
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_matched_classes.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#matched_classes_filter_list.bp_popup_list
-            %th
-              Matched Ontology
-              %span.popup_container
-                %span.bp_popup_link_container
-                  %a#filter_matched_ontologies.bp_popup_link{:href => "javascript:void(0);"} filter
-                %div#matched_ontology_filter_list.bp_popup_list
+            %th Matched Class
+            %th Matched Ontology
             %th Score
             %th Negation
             %th Experiencer

--- a/app/views/annotatorplus/index.html.haml
+++ b/app/views/annotatorplus/index.html.haml
@@ -125,8 +125,7 @@
 %div.row
   %div.col
     #annotations_container{'data-controller': 'annotator-plus-table'}
-      #result_counts
-      %h4 Annotations
+      %h4.mb-3 Annotations
       #results_error{:style => "color: red; margin-bottom: 7px;"}
       %table#annotations.table.table-striped{:style => "min-width: 700px; width: 100%;", 'data-annotator-plus-table-target': 'table'}
         %thead

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "chart.js": "^4.4.1",
     "d3": "^7.8.5",
     "datatables.net-bs5": "^2.3.8",
+    "datatables.net-columncontrol-bs5": "^1.2.1",
     "debounce": "^1.2.1",
     "esbuild": "~0.25.11",
     "flatpickr": "^4.6.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,7 +765,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-datatables.net-bs5@^2.3.8:
+datatables.net-bs5@^2.3.2, datatables.net-bs5@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/datatables.net-bs5/-/datatables.net-bs5-2.3.8.tgz#7266636ff488429988ca664bc8cb0b7c5e48c563"
   integrity sha512-TbFH99QSWm93Kn3teHLFKeyOqYbaiddlHvRFdXUwAvh/fjTMhACWmHG+I43ss8d23OEFHV0WIbN4lpPusZm5zw==
@@ -773,7 +773,22 @@ datatables.net-bs5@^2.3.8:
     datatables.net "2.3.8"
     jquery ">=1.7"
 
-datatables.net@2.3.8:
+datatables.net-columncontrol-bs5@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-columncontrol-bs5/-/datatables.net-columncontrol-bs5-1.2.1.tgz#4da8328076b456336c5c656027c8769b644a74c0"
+  integrity sha512-gZeND0C0QEG3bEpO8r50XXh+CYXlnEbd0j33Y//YbGwN9tkB9kJ52dttr4QLvZyZ9N1L4DBXEWKACf4nhehCNQ==
+  dependencies:
+    datatables.net-bs5 "^2.3.2"
+    datatables.net-columncontrol "1.2.1"
+
+datatables.net-columncontrol@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-columncontrol/-/datatables.net-columncontrol-1.2.1.tgz#13331712b0bc4b029bb6e494dcd59b4b2c007473"
+  integrity sha512-NWh5CykZ1y+LiuKUHuDGKPM7glbj7nop7vk7htTrN8OqmEPlUZImUK9JJKJqMvs3qY0LzxQ4o8kX8Qu/eMNSaA==
+  dependencies:
+    datatables.net "^2.3.2"
+
+datatables.net@2.3.8, datatables.net@^2.3.2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-2.3.8.tgz#55a8dbe3bd2196951c498ab79bf44602a2bf3229"
   integrity sha512-uhViowhlDlheAuo5a8TrkQqADsjrtGeOyvrigvr4t0+K3MyAWqClORXWAYIcN9VLX6iIX0C8O9gwJNd01hITRg==


### PR DESCRIPTION
## Summary

Follow-up to #518 (DataTables 2.x upgrade), tackling the third follow-up bullet: **evaluate the official ColumnControl extension to replace the custom annotator filter popups.** This adopts ColumnControl on both the Annotator and AnnotatorPlus results tables, retiring a large amount of bespoke jQuery, and refreshes the surrounding table chrome (paging + a results summary).

## What changed

**ColumnControl filtering (replaces the custom "filter" popups)**
- Added the `datatables.net-columncontrol-bs5` extension (JS import + SCSS).
- Filterable columns (Class, Ontology, Type, Matched Class, Matched Ontology) now use a ColumnControl hamburger dropdown with an `order` button and a `searchList` (checkbox list + search box), using the `filter` orthogonal data so labels are tag-stripped.
- Removed the hand-rolled popup markup from both views and ~340 lines of bespoke jQuery filter code from each of `bp_annotator.js` and `bp_annotatorplus.js` (the five filter objects, checkbox generation, filtered-name display, and `removeFilters`), plus the now-orphaned popup CSS.
- Filter options are rebuilt after each annotation run via `columnControl.searchList('refresh')`; filters reset via `columnControl.searchClear()`.

**Paging + info controls**
- Enabled paging (25 rows/page) on both tables.
- Replaced the `#result_counts` div with a top-start `div` layout feature showing a grand-total summary — `Total results: N (direct N / ancestor N / mapping N)` — populated on `draw` via a shared `buildAnnotationsSummary` helper (`app/javascript/utils/annotations_info.js`). The total/breakdown reflect the full result set and intentionally ignore column filters.
- Kept a single default `info` control at bottom-start for the per-page "Showing X to Y of Z" line, so it retains the `aria-live`/`role=status`/`aria-describedby` semantics (a second `info` control would have hijacked those).
- Summary styled with `text-muted` (Bootstrap 5.2.3-compatible).

## Notes / decisions

- **No default sort** — insertion order is intentional; it groups direct/ancestor/mapping rows per annotation. Preserved on both tables.
- The shared `bp_popup_init`/`bp_popup_cleanup` helpers and `.bp_popup_*` styles remain, still used by the advanced ontology picker.

## Testing

Verified manually and via headless Chrome against a running instance on both `/annotator` and `/annotatorplus`: searchList filtering narrows rows correctly, options refresh per annotation run, the top-start summary populates with the correct totals/breakdown, and the single bottom `info` element carries the aria semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
