### PR TITLE
Switch Font Awesome CDN to cdnjs to fix CORS breakage

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
 	<link href='//fonts.googleapis.com/css?family=Droid+Sans:400' rel='stylesheet' type='text/css'>
 
 	<!-- CSS -->
-  <%= stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous" %>
+  <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm", crossorigin: "anonymous" %>
 	<%= stylesheet_link_tag 'flag-icon', 'data-turbo-track': 'reload' %>
   <%= stylesheet_link_tag "application" %>
 

--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -29,7 +29,7 @@
   <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
   <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400' rel='stylesheet' type='text/css'>
-  <%= stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous" %>
+  <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm", crossorigin: "anonymous" %>
   <%= stylesheet_link_tag "application" %>
 </head>
 <body class="<%= controller_name %> <%= action_name %> d-flex flex-column h-100">

--- a/app/views/layouts/appliance.html.haml
+++ b/app/views/layouts/appliance.html.haml
@@ -11,7 +11,7 @@
     <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />
     
     = stylesheet_link_tag "//fonts.googleapis.com/css?family=Droid+Sans:400", media: "all"
-    = stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous"
+    = stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm", crossorigin: "anonymous"
     = stylesheet_link_tag 'flag-icon', 'data-turbo-track': 'reload'
     = stylesheet_link_tag "application", media: "all"
 

--- a/app/views/layouts/partial.html.erb
+++ b/app/views/layouts/partial.html.erb
@@ -5,7 +5,7 @@
 <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
 <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />
 <link href='//fonts.googleapis.com/css?family=Droid+Sans:400' rel='stylesheet' type='text/css'>
-<%= stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous" %>
+<%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm", crossorigin: "anonymous" %>
 <%= stylesheet_link_tag "application" %>
 
 <%=render partial: 'layouts/js_data'%>

--- a/app/views/layouts/popup.html.erb
+++ b/app/views/layouts/popup.html.erb
@@ -8,7 +8,7 @@
   <title><%if @title.nil?%><%=$ORG_SITE%><%else%><%="#{@title} | #{$ORG_SITE}"%><%end%></title>
   <link rel="shortcut icon" href="/fav.ico" type="image/x-icon" />
   <link href='//fonts.googleapis.com/css?family=Droid+Sans:400' rel='stylesheet' type='text/css'>
-  <%= stylesheet_link_tag "https://use.fontawesome.com/releases/v5.2.0/css/all.css", integrity: "sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ", crossorigin: "anonymous" %>
+  <%= stylesheet_link_tag "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css", integrity: "sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm", crossorigin: "anonymous" %>
   <%= stylesheet_link_tag "application" %>  
   <%= javascript_include_tag "vendor" %>
   <%= javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.min.js" %>


### PR DESCRIPTION
Refs #520

## Problem

Font Awesome's legacy CDN (`use.fontawesome.com`) stopped sending the `Access-Control-Allow-Origin` header. Because our `stylesheet_link_tag` calls use `integrity:` + `crossorigin: "anonymous"`, browsers fetch the stylesheet in CORS mode and are required to block the response — so all Font Awesome icons disappeared in production with no change on our side.

## Change

One-line swap in the five layouts that load Font Awesome (`_header.html.erb`, `angular.html.erb`, `popup.html.erb`, `appliance.html.haml`, `partial.html.erb`):

- **URL:** `https://use.fontawesome.com/releases/v5.2.0/css/all.css` → `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css` (cdnjs serves `access-control-allow-origin: *`, verified)
- **SRI hash:** updated to the sha384 of the cdnjs file, computed from the served content and matching cdnjs's published hash
- 5.15.4 is the final v5 release — a strict superset of 5.2.0's icons with unchanged class names, so no markup changes are needed

This is the immediate hotfix (Option A in #520). The durable follow-up is self-hosting via the `@fortawesome/fontawesome-free` npm package through the existing esbuild/Sass pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
