### PR TITLE
Improve class browser UX and styling on the Classes tab

### DIFF
--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -285,6 +285,25 @@ $bd-bottom-gap: 30px;
   overscroll-behavior: contain;
 }
 
+// Keep the details pane from collapsing while a concept's Turbo frame reloads.
+// TurboFrameComponent normally hides .hide-if-loading and shows a small centered
+// loader while the frame is [busy]. Because the flex-chain rule above forces
+// .hide-if-loading to display:flex, that swap was left in an inconsistent state
+// and the pane visibly shrank then re-expanded ("jump") on every concept select.
+// Here we make the busy state explicit: hide the content, and let the loader
+// fill the pane's full height (centered) so its dimensions stay stable through
+// the load. Scoped to the details frame so nested frames are unaffected.
+#bd_content #concept_content > .d-flex > turbo-frame#concept_show[busy] > .hide-if-loading {
+  display: none !important;
+}
+#bd_content #concept_content > .d-flex > turbo-frame#concept_show[busy] ~ .show-if-loading {
+  display: flex !important;
+  flex: 1 1 auto;
+  min-height: 0;
+  align-items: center;
+  justify-content: center;
+}
+
 // The tree tab's content wrapper is a Bootstrap .p-1 (padding: .25rem !important),
 // so the "Jump to" search box sat cramped against the tab bar and pane edges.
 // Give it comfortable room; !important is needed to beat the .p-1 utility.

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -285,23 +285,32 @@ $bd-bottom-gap: 30px;
   overscroll-behavior: contain;
 }
 
-// Keep the details pane from collapsing while a concept's Turbo frame reloads.
+// Keep the details pane stable while a concept's Turbo frame reloads.
 // TurboFrameComponent normally hides .hide-if-loading and shows a small centered
-// loader while the frame is [busy]. Because the flex-chain rule above forces
-// .hide-if-loading to display:flex, that swap was left in an inconsistent state
-// and the pane visibly shrank then re-expanded ("jump") on every concept select.
-// Here we make the busy state explicit: hide the content, and let the loader
-// fill the pane's full height (centered) so its dimensions stay stable through
-// the load. Scoped to the details frame so nested frames are unaffected.
+// loader while the frame is [busy]. With the viewport-bounding layout that made
+// the pane collapse to the loader's height and then re-expand ("jump") on every
+// concept select — and hiding the content also blanked the whole pane.
+// Instead, while #concept_show is [busy] we keep the previous content in place
+// and float the loader over it as a full-pane overlay with a translucent
+// backdrop. The pane keeps its dimensions and never goes blank; the outgoing
+// content is simply veiled until the new content swaps in. The positioning
+// context is the .d-flex wrapper (position: relative below). Scoped via the
+// direct-child path so nested mapping/notes frames are unaffected.
+#bd_content #concept_content > .d-flex {
+  position: relative;
+}
 #bd_content #concept_content > .d-flex > turbo-frame#concept_show[busy] > .hide-if-loading {
-  display: none !important;
+  display: flex !important;
 }
 #bd_content #concept_content > .d-flex > turbo-frame#concept_show[busy] ~ .show-if-loading {
   display: flex !important;
-  flex: 1 1 auto;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  margin: 0;
   align-items: center;
   justify-content: center;
+  background: rgba(255, 255, 255, 0.65);
 }
 
 // The tree tab's content wrapper is a Bootstrap .p-1 (padding: .25rem !important),

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -326,7 +326,10 @@ $bd-bottom-gap: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5em;
+  // Reserve just enough width for a single-digit count or the (slightly wider)
+  // busy spinner, so the two swap without a jump while the parentheses stay
+  // snug. min-width (not width) lets longer counts expand instead of clipping.
+  min-width: 1.25em;
 
   > .d-flex.flex-column {
     width: 100%;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -313,6 +313,32 @@ $bd-bottom-gap: 30px;
   background: rgba(255, 255, 255, 0.65);
 }
 
+// The Mappings tab shows a lazy count (#mapping_count Turbo frame). Two issues
+// on every concept select:
+//  - the count's TurboFrameComponent wrapper is a flex COLUMN holding both the
+//    frame (with its own busy spinner) and a sibling .show-if-loading loader;
+//    during a real fetch both showed, stacking TWO circular spinners vertically
+//    below the tab label. Suppress the redundant sibling loader — the frame's
+//    own busy spinner is enough.
+//  - the number<->spinner swap changed the label width and jumped the tab bar;
+//    a fixed footprint keeps the label width constant.
+#concept_content .concepts-mapping-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5em;
+
+  > .d-flex.flex-column {
+    width: 100%;
+    align-items: center;
+
+    // the redundant second loader that stacked below the count
+    > .show-if-loading {
+      display: none !important;
+    }
+  }
+}
+
 // The tree tab's content wrapper is a Bootstrap .p-1 (padding: .25rem !important),
 // so the "Jump to" search box sat cramped against the tab bar and pane edges.
 // Give it comfortable room; !important is needed to beat the .p-1 utility.

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -1,9 +1,12 @@
 $ont-metadata-bg-color: #e2ebf0;
 $widget-table-border-color: #EFEFEF;
 $ont-show-bg-color: #e9ecef;
+// #concept_details flows naturally inside the details column's single scroll
+// region (see the `#concept_content .tab-content` rule in the "Classes pane"
+// section). It must NOT be its own scroller, or the column gets a nested
+// scrollbar that fights the outer one.
 #concept_details {
-  max-height: 90vh;
-  overflow-y: auto;
+  min-height: 0;
 }
 .ontologies.show,
 .ontologies.admin {
@@ -181,15 +184,162 @@ $ont-show-bg-color: #e9ecef;
 /* Classes pane
 ************************************/
 
+// The main ontology-viewer tab bar (Summary / Classes / … plus the language
+// selector on the right) had no vertical padding, so the language <select> sat
+// flush against the bar's bottom border. Add symmetric vertical padding so its
+// controls breathe. Scoped to this instance so other tab bars are unaffected.
+#ontology_viewer.tabs-container {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+// The two-column class browser fills the space from its top down to a small
+// gap above the bottom of the viewport, and each column scrolls internally
+// instead of the whole page. `--bd-content-top` is the distance from the top of
+// the viewport to the top of #bd_content (site header + ontology card + tab
+// bar); it is measured and set on connect by the container-splitter Stimulus
+// controller so this stays correct across breakpoints and header changes. The
+// fallback keeps the layout sane before JS runs / if the controller is absent.
+// $bd-bottom-gap leaves visible breathing room so the region's bottom edge (and
+// both panes' lower boundaries) sit comfortably above the fold. It matches the
+// container's 30px left/right gutter so the pale page background frames the
+// panels evenly on all four sides.
+$bd-bottom-gap: 30px;
 #bd_content {
   display: flex;
   flex-direction: row;
+  align-items: stretch;
+  // Breathing room between the tab / language-selector row above and the
+  // panels, so the language box isn't cramped against the panel outline.
+  // Included in --bd-content-top (the controller measures the top edge), so
+  // the height calc stays correct.
+  margin-top: 12px;
+  height: calc(100dvh - var(--bd-content-top, 340px) - #{$bd-bottom-gap});
+  overflow: hidden;
 }
 
-#bd_content .sidebar {
+// Each column (and the resizer gutter) fills the row height. min-height:0 is
+// required so a flex child may shrink below its content and delegate the
+// overflow to the inner scroller.
+#bd_content .sidebar,
+#bd_content #concept_content {
   white-space: wrap;
-  min-height: 70vh;
-  max-height: 90vh;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+// For the height to reach each column's scroll region, every wrapper between
+// the column and its scroller must be a flex column that can shrink
+// (min-height:0). The two columns share the TabsContainerComponent skeleton but
+// differ in their deeper wrappers. The wrapper chains below were verified
+// against the rendered DOM:
+//
+// Left (sidebar), scroller = #sd_content:
+//   #concept_browser
+//     └ .tab-content            (sibling of the .tabs-container tab bar)
+//         └ .tab-pane.active     (#tree_tab_content)
+//             └ .p-1
+//                 └ div[data-controller~="skos-collection-colors"]
+//                     ├ .pb-2            (the "Jump to" box — stays fixed)
+//                     └ #sd_content      (the scroller — grows)
+//
+// Right (details), scroller = .tab-content itself:
+//   #concept_content
+//     └ .d-flex[data-controller~="turbo-frame-error"]
+//         └ turbo-frame#concept_show
+//             └ .hide-if-loading
+//                 └ div[data-controller~="concepts-json"]
+//                     ├ .tabs-container   (the tab bar — stays fixed)
+//                     └ .tab-content      (the scroller — grows)
+#bd_content .sidebar #concept_browser,
+#bd_content .sidebar #concept_browser .tab-content,
+#bd_content .sidebar #concept_browser .tab-pane.active,
+#bd_content .sidebar #concept_browser .tab-pane.active > .p-1,
+#bd_content .sidebar #concept_browser .tab-pane.active > .p-1 > [data-controller~="skos-collection-colors"],
+#bd_content #concept_content > .d-flex,
+#bd_content #concept_content turbo-frame#concept_show,
+#bd_content #concept_content .hide-if-loading,
+#bd_content #concept_content [data-controller~="concepts-json"] {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+// The single scroll region per column. overscroll-behavior:contain stops a
+// scroll that reaches the end from chaining out to the page.
+#sd_content,
+#bd_content #concept_content .tab-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto !important;   // override the inline height:60vh on #sd_content
+  max-height: none;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+// The tree tab's content wrapper is a Bootstrap .p-1 (padding: .25rem !important),
+// so the "Jump to" search box sat cramped against the tab bar and pane edges.
+// Give it comfortable room; !important is needed to beat the .p-1 utility.
+#bd_content .sidebar #concept_browser .tab-pane.active > .p-1 {
+  padding: 12px !important;
+}
+
+// Small gutter at the very top of the details scroll region so the first data
+// row isn't flush against the pinned tab bar. The border matches the outline on
+// the tree column's tab bar (.outline-tabs) so the two columns read as matching
+// enclosed panels with aligned top edges. No top border: the tab bar's own
+// bottom border already draws the divider there — a top border would double it.
+// Rounded only at the bottom corners, since the tab bar caps the top.
+#bd_content #concept_content .tab-content {
+  padding-top: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+}
+
+// The details content has two inset boxes that each draw their own border,
+// which read as second/nested rectangles inside our enclosing pane outline (the
+// tree column shows only one outline):
+//   .card              — the top summary block (Id / Preferred Name / …)
+//   .dropdown-container — the collapsible "All Properties" block
+// Drop both inner borders + rounding here so the pane reads as a single enclosed
+// panel like the hierarchy. Scoped to the details pane so these shared
+// components keep their borders everywhere else.
+#bd_content #concept_content .tab-content .card,
+#bd_content #concept_content .tab-content .dropdown-container {
+  border: none;
+  border-radius: 0;
+}
+
+// The collapsible section headers (e.g. "All Properties") use .dropdown-title-bar,
+// which globally spreads its label and expand/collapse chevron to opposite ends
+// (justify-content: space-between). In the details pane that leaves the chevron
+// stranded at the far right edge, disconnected from its label. Pull them
+// together at the start and let the label size to its text so the chevron sits
+// just after it. Scoped to the details pane so other dropdowns are unaffected.
+#bd_content #concept_content .tab-content .dropdown-title-bar {
+  justify-content: flex-start;
+
+  .header-component {
+    flex: 0 0 auto;
+    width: auto;
+  }
+}
+
+// Tab bars (Hierarchy/Collection/Date on the left; Details/Visualization/Notes/
+// Mappings on the right) keep their natural height and stay pinned while the
+// content scrolls beneath them. The opaque background keeps scrolled content
+// from showing through. The pane's bottom border (above) draws the single
+// divider under the tab bar — no shadow, which otherwise doubled the line.
+#bd_content [data-controller~="tabs-container"] {
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 2;
+  background: var(--bs-body-bg, #fff);
 }
 
 #search_box:focus {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -258,7 +258,11 @@ $bd-bottom-gap: 30px;
 #bd_content .sidebar #concept_browser .tab-content,
 #bd_content .sidebar #concept_browser .tab-pane.active,
 #bd_content .sidebar #concept_browser .tab-pane.active > .p-1,
-#bd_content .sidebar #concept_browser .tab-pane.active > .p-1 > [data-controller~="skos-collection-colors"],
+// The direct-child wrapper inside .p-1 that holds the search box + #sd_content.
+// On the hierarchy tab this is a [data-controller~="skos-collection-colors"] div;
+// on the list (Collections) and date tabs it's a plain <div>. Both must become
+// flex columns or #sd_content can't flex and the list clips with no scroll.
+#bd_content .sidebar #concept_browser .tab-pane.active > .p-1 > div,
 #bd_content #concept_content > .d-flex,
 #bd_content #concept_content turbo-frame#concept_show,
 #bd_content #concept_content .hide-if-loading,

--- a/app/assets/stylesheets/tree.scss
+++ b/app/assets/stylesheets/tree.scss
@@ -6,9 +6,11 @@
   transform: rotate(90deg);
 }
 
+// The tree scrolls inside #sd_content (see the Classes-pane rules in
+// ontologies.scss), so the wrapper itself must not impose its own height or a
+// second scrollbar — let it grow to its natural content height.
 #tree_wrapper {
-  max-height: 75vh;
-  overflow-y: auto;
+  min-height: 0;
 }
 
 div.tree_error {

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -28,8 +28,8 @@ module ComponentsHelper
     render LabelFetcherComponent.new(id: id, label: label, link: link, open_in_modal: open_in_modal, ajax_src: ajax_src, target: target, external: external)
   end
 
-  def tab_item_component(container_tabs:, title:, path:, selected: false, json_link: "", &content)
-    container_tabs.with_item(title: title.html_safe, path: path, selected: selected, json_link: json_link)
+  def tab_item_component(container_tabs:, title:, path:, id: nil, selected: false, json_link: "", &content)
+    container_tabs.with_item(id: id, title: title.html_safe, path: path, selected: selected, json_link: json_link)
     container_tabs.with_item_content { capture(&content) }
   end
 

--- a/app/javascript/controllers/container_splitter_controller.js
+++ b/app/javascript/controllers/container_splitter_controller.js
@@ -6,6 +6,18 @@ export default class extends Controller {
 
   connect() {
     this.element.style.display = 'flex';
+
+    // Publish the distance from the top of the viewport to the top of
+    // #bd_content as a CSS custom property, so the layout can size the class
+    // browser to `calc(100dvh - var(--bd-content-top) - gap)` and keep both
+    // columns scrolling internally instead of the whole page. Measured now, once
+    // more after layout settles (fonts/images above can shift the offset), and
+    // kept current on resize.
+    this.updateTopOffset = this.updateTopOffset.bind(this);
+    this.updateTopOffset();
+    requestAnimationFrame(this.updateTopOffset);
+    window.addEventListener('resize', this.updateTopOffset);
+
     if (this.element.getAttribute('splitter-data-initial') == 0) {
       return;
     }
@@ -27,5 +39,16 @@ export default class extends Controller {
       cursor: "col-resize"
     });
     this.element.setAttribute('splitter-data-initial', 0);
+  }
+
+  disconnect() {
+    if (this.updateTopOffset) {
+      window.removeEventListener('resize', this.updateTopOffset);
+    }
+  }
+
+  updateTopOffset() {
+    const top = Math.round(this.element.getBoundingClientRect().top + window.scrollY);
+    this.element.style.setProperty('--bd-content-top', `${top}px`);
   }
 }

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -34,19 +34,51 @@ export default class extends Controller {
 
       if (isTreeViewPage) {
         const activeElem = this.element.querySelector('.tree-link.active');
-        
+
         if (activeElem) {
-          activeElem.scrollIntoView({ block: 'center' });
-          window.scrollTo({ top: 0 });
-          
+          this.#centerWithinScrollParent(activeElem);
+
           if (this.autoClickValue) {
             activeElem.click();
           }
         }
-        
+
         this.#onClickTooManyChildrenInit();
       }
     }, 0);
+  }
+
+  // Center the active node inside the tree's own scroll container only.
+  // Using element.scrollIntoView() here would also scroll the window (it walks
+  // every scrollable ancestor), producing a visible page "jump" on load that a
+  // follow-up window.scrollTo(0) then snapped back. Scrolling the container
+  // directly avoids touching the page scroll entirely.
+  #centerWithinScrollParent (activeElem) {
+    const scroller = activeElem.closest('#sd_content') || this.#nearestScrollParent(activeElem);
+    if (!scroller) return;
+
+    // Node's top relative to the scroller's content box, independent of how many
+    // wrapper elements sit between them (offsetParent can be either).
+    const elemRect = activeElem.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    const offsetWithinScroller = (elemRect.top - scrollerRect.top) + scroller.scrollTop;
+
+    const target = offsetWithinScroller
+      - (scroller.clientHeight / 2)
+      + (elemRect.height / 2);
+    scroller.scrollTop = Math.max(0, target);
+  }
+
+  #nearestScrollParent (el) {
+    let node = el.parentElement;
+    while (node) {
+      const overflowY = getComputedStyle(node).overflowY;
+      if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight) {
+        return node;
+      }
+      node = node.parentElement;
+    }
+    return null;
   }
 
   #onClickTooManyChildrenInit () {

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -8,20 +8,25 @@
       = ontology_object_tabs_component(ontology_id: @ontology.acronym, objects_title: "classes", object_id: @concept.id) do |c|
         - apikey = "apikey=#{get_apikey}"
         - baseClassUrl = "#{@ontology.id}/classes/#{escape(@concept.id)}"
-        - tab_item_component(container_tabs: c, title: t('concepts.details'), path: '#details', selected: true, json_link: "#{baseClassUrl}?#{apikey}&display=all") do
+        -# Pass explicit ids: without one, TabItemComponent derives the item id
+        -# (and thus the tab-pane id) by parameterizing the title HTML. For Notes
+        -# and Mappings the title embeds a count span / lazy loader frame, which
+        -# produced a mangled id and a stray duplicate loader spinner in the tab
+        -# bar. Stable ids keyed off the path avoid that.
+        - tab_item_component(container_tabs: c, id: 'details', title: t('concepts.details'), path: '#details', selected: true, json_link: "#{baseClassUrl}?#{apikey}&display=all") do
           = render :partial =>'/concepts/details'
 
-        - tab_item_component(container_tabs: c, title: t('concepts.visualization'), path: '#visualization') do
+        - tab_item_component(container_tabs: c, id: 'visualization', title: t('concepts.visualization'), path: '#visualization') do
           = render :partial =>'/concepts/biomixer'
 
 
         - count_span = content_tag(:span, "#{t('concepts.notes')} (#{content_tag(:span, @notes.length, id: 'note_count')})".html_safe)
-        - tab_item_component(container_tabs: c, title: count_span, path: '#notes', json_link: "#{baseClassUrl}/notes?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'notes', title: count_span, path: '#notes', json_link: "#{baseClassUrl}/notes?#{apikey}") do
           = render :partial =>'/notes/list'
 
 
         - count_span = content_tag(:span, "#{t('concepts.mappings')} (#{content_tag(:span, concept_mappings_loader(ontology_acronym: @ontology.acronym, concept_id: @concept.id))})".html_safe, class: "d-flex")
-        - tab_item_component(container_tabs: c, title: count_span, path: '#mappings', json_link: "#{baseClassUrl}/mappings?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'mappings', title: count_span, path: '#mappings', json_link: "#{baseClassUrl}/mappings?#{apikey}") do
           = render TurboFrameComponent.new(id:'concept_mappings',
           src:"/ajax/mappings/get_concept_table?ontologyid=#{@ontology.acronym}&conceptid=#{CGI.escape(@concept.id)}")
 

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -12,7 +12,10 @@
         -# (and thus the tab-pane id) by parameterizing the title HTML. For Notes
         -# and Mappings the title embeds a count span / lazy loader frame, which
         -# produced a mangled id and a stray duplicate loader spinner in the tab
-        -# bar. Stable ids keyed off the path avoid that.
+        -# bar. Stable ids keyed off the path avoid that. Notes and Mappings are
+        -# prefixed with "concept-" because the ontology-level Notes and Mappings
+        -# sections already render #notes_content / #mappings_content wrappers,
+        -# and both sections can be in the DOM at once (hidden, not removed).
         - tab_item_component(container_tabs: c, id: 'details', title: t('concepts.details'), path: '#details', selected: true, json_link: "#{baseClassUrl}?#{apikey}&display=all") do
           = render :partial =>'/concepts/details'
 
@@ -21,12 +24,12 @@
 
 
         - count_span = content_tag(:span, "#{t('concepts.notes')} (#{content_tag(:span, @notes.length, id: 'note_count')})".html_safe)
-        - tab_item_component(container_tabs: c, id: 'notes', title: count_span, path: '#notes', json_link: "#{baseClassUrl}/notes?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'concept-notes', title: count_span, path: '#notes', json_link: "#{baseClassUrl}/notes?#{apikey}") do
           = render :partial =>'/notes/list'
 
 
         - count_span = content_tag(:span, "#{t('concepts.mappings')} (#{content_tag(:span, concept_mappings_loader(ontology_acronym: @ontology.acronym, concept_id: @concept.id))})".html_safe, class: "d-flex")
-        - tab_item_component(container_tabs: c, id: 'mappings', title: count_span, path: '#mappings', json_link: "#{baseClassUrl}/mappings?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'concept-mappings', title: count_span, path: '#mappings', json_link: "#{baseClassUrl}/mappings?#{apikey}") do
           = render TurboFrameComponent.new(id:'concept_mappings',
           src:"/ajax/mappings/get_concept_table?ontologyid=#{@ontology.acronym}&conceptid=#{CGI.escape(@concept.id)}")
 

--- a/app/views/ontologies/concepts_browsers/_concepts_date_sort.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_date_sort.html.haml
@@ -1,2 +1,2 @@
-%div#sd_content.card.p-1{style: 'overflow-y: scroll; height: 60vh;'}
+%div#sd_content.card.p-1
   = render TurboFrameComponent.new(id:'concepts_date_sorted_list_view-page-1' , src: sorted_by_date_url)

--- a/app/views/ontologies/concepts_browsers/_concepts_list.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_list.html.haml
@@ -13,7 +13,7 @@
                    data: {action: 'changed->turbo-frame#updateFrame'}}
 
   - unless no_collections?
-    %div#sd_content.card.p-1{style: 'overflow-y: auto; height: 60vh;'}
+    %div#sd_content.card.p-1
       = render TurboFrameComponent.new(id: 'concepts_list_view-page-1', data: {'turbo-frame-target': 'frame'}, src:params[:concept_collections] ? "/ajax/classes/list?ontology_id=#{@ontology.acronym}&collectionid=#{params[:concept_collections]}" : '') do
         .select-collection-placeholder
           = t("ontologies.concepts_browsers.select_collection") 

--- a/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
+++ b/app/views/ontologies/concepts_browsers/_concepts_tree.html.haml
@@ -15,7 +15,9 @@
                        data: {action: 'changed->skos-collection-colors#updateCollectionTags' ,
                         'skos-collections-selector-enable-colors-value': 'true'}}
   -# Class tree
-  %div#sd_content.px-1{style: 'overflow-y: scroll; height: 60vh;'}
+  -# Height + overflow are handled by the #sd_content rule in ontologies.scss
+  -# so the tree fills its column and scrolls independently.
+  %div#sd_content.px-1
     - if skos? && @roots&.empty?
       %div.text-wrap
         = render Display::AlertComponent.new do


### PR DESCRIPTION
## Summary

Improves the UX and styling of the two-column class browser on the ontology **Classes** tab (tree on the left, concept details on the right).

The two columns were sized with viewport-relative heights (`60vh` / `70vh` / `75vh` / `90vh`) that ignored how far down the page the columns actually start. As a result the **whole page scrolled** instead of each column scrolling on its own, the tree never filled the available height, and the details pane's fixed-height inner scroller produced a nested/awkward second scrollbar. This PR reworks the layout so the browser region is bounded to the viewport with one internal scroll region per column, and tidies up the surrounding spacing, borders, and controls.

## What changed

**Layout / scrolling**
- The browser region (`#bd_content`) is now bounded to the viewport (`height: calc(100dvh - var(--bd-content-top) - 30px)`) and clips its overflow, so the page itself no longer scrolls.
- Each column gets a single internal scroll region (the tree on the left, the details tab content on the right) with `overscroll-behavior: contain`, so reaching the end of one pane doesn't chain-scroll the page.
- The tree and details **tab bars stay pinned** while their content scrolls beneath them.
- Removed the hardcoded inline `height: 60vh` from the three browser partials; the fixed `max-height` on the details pane and `#tree_wrapper` are gone too.

**Page-load behaviour**
- Fixed a visible **"jump"** on load: the tree used to center the selected node with `element.scrollIntoView()` and then `window.scrollTo(0)`, which scrolled the whole page and snapped it back. It now scrolls only the tree's own container, so the page never moves.

**Styling**
- The details pane now reads as a **single enclosed panel** matching the tree column's outline — one border, no doubled line under the tab bar, and no nested inset box around the summary / "All Properties" cards.
- The pale page background now frames the panels **evenly on all four sides** (bottom gap matched to the side gutters).
- Collapsible section headers (e.g. "All Properties") place their **expand/collapse chevron next to the label** instead of stranded at the far right.
- Extra breathing room around the language selector and the tree's "Jump to" **search box**, which were previously cramped.

## Before / after

| | Before (production) | After (this PR) |
|---|---|---|
| On load | whole page scrolls; tree in a short fixed box; details pane has its own inner scrollbar | region fits the viewport; tree & details each scroll internally; page stays put |
| Details pane | nested inset card border inside the pane; doubled line under tab bar | single clean outline matching the tree column |
| Section chevron | pinned to the far right edge | sits next to its label |

### Before (current production)

Whole page scrolls; tree sits in a short fixed box and the details pane has its own inner scrollbar.

| Top of page | Scrolled down |
|---|---|
| ![before, top](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/pr-assets/before-top.jpg) | ![before, scrolled](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/pr-assets/before-scrolled.jpg) |

### After (this PR)

Region fits the viewport; tree and details each scroll internally with the page fixed; single clean panel outlines.

| Top of page | Details scrolled (page fixed) |
|---|---|
| ![after, top](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/pr-assets/after-top.jpg) | ![after, scrolled](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/pr-assets/after-scrolled.jpg) |

## How to test

1. Open any ontology's **Classes** tab with a concept selected, e.g. `/ontologies/BCIO?p=classes&conceptid=<iri>`.
2. Confirm the page itself does not scroll; the tree and the details pane each scroll on their own.
3. Confirm the selected tree node is centered in the tree on load, with no page "jump".
4. Confirm the details pane is a single outlined panel and the "All Properties" chevron sits beside its label.

## Notes / implementation detail

- `--bd-content-top` (the region's distance from the top of the document) is measured and published at runtime by the existing `container-splitter` Stimulus controller, re-measured after layout settles and on resize, so the height calc stays correct across header sizes and breakpoints. A `340px` fallback keeps the layout sane before JS runs.
- CSS overrides that touch shared components (`.card`, `.dropdown-container`, `.dropdown-title-bar`) are **scoped to the details pane** so those components are unaffected elsewhere.

## Follow-ups (out of scope for this PR)

- [ ] Duplicate DOM ids: `#sd_content` is emitted by all three browser-mode partials and `#concepts_tree_view` renders more than once — invalid HTML worth cleaning up at the source (Turbo frames).
- [ ] Optionally equalize the ~16px gap between the tab bar and the panels with the 30px outer frame for a fully uniform inset.
