### PR TITLE
Modernize the ontologies browse page

### DIFF
--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -720,6 +720,16 @@ $browse-gap: 24px;
   white-space: nowrap;
 }
 
+// Search-term highlight in result names/acronyms. Soft gold wash (matching the
+// acronym pill family) so the matched substring stands out without shouting;
+// inherits the surrounding text colour so link/pill text stays readable.
+#ontologies mark.search-hl {
+  background: rgba(197, 134, 18, 0.28);
+  color: inherit;
+  border-radius: 3px;
+  padding: 0 0.05em;
+}
+
 // Each ontology row as a clean, framed card that lifts on hover (the title is a
 // link, so the whole card reads as interactive).
 #ontologies .ontology.grid-parent {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -462,11 +462,398 @@ $bd-bottom-gap: 30px;
  * Browse page (index)
  ************************************/
 
+// The browse (/ontologies) page is a legacy AngularJS view using the unsemantic
+// grid and its own class names. These rules realign its look with the modern
+// Rails/ViewComponent pages (Classes tab etc.): framed cards, flat light stat
+// pills, and a cleaner facet sidebar — without touching the Angular logic.
+
+// Bound the two-column browse area to the viewport and scroll each column
+// internally: the search/sort toolbar stays pinned, the facet sidebar stays in
+// place, and only the ontology list scrolls. $browse-top is the distance from
+// the top of the viewport to the top of the columns (site header + page top
+// padding); $browse-gap leaves a little room at the bottom.
+$browse-top: 96px;
+$browse-gap: 24px;
+
+#facets,
+#ontologies {
+  height: calc(100vh - #{$browse-top} - #{$browse-gap});
+  box-sizing: border-box;
+}
+
+// Facet sidebar scrolls on its own when it's taller than the viewport. A little
+// right padding keeps the scrollbar off the panel edge.
+#facets {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 0.5rem;
+}
+
+// Right column: the toolbar is fixed at the top, the ontology list scrolls.
+#ontologies {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .browse-toolbar { flex: 0 0 auto; }
+
+  // The list scrolls; the right padding keeps its scrollbar clear of the cards.
+  .ontology-list {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 1rem;
+  }
+}
+
 .ontology.grid-parent h2 {
   a {
     text-decoration: none;
+    color: var(--primary-color);
   }
   a:hover {
     text-decoration: underline;
   }
+}
+
+// Each ontology row as a clean, framed card that lifts on hover (the title is a
+// link, so the whole card reads as interactive).
+#ontologies .ontology.grid-parent {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  padding: 1.1rem 1.35rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    border-color: rgba(35, 73, 121, 0.35);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08);
+  }
+
+  h2 {
+    font-size: 1.1rem;
+    margin-bottom: 0.3rem;
+    line-height: 1.3;
+  }
+
+  // Description is secondary: muted, and clamped to two lines so every card
+  // keeps a consistent height regardless of how long/short the text is.
+  p {
+    color: #5c6470;
+    font-size: 0.9rem;
+    line-height: 1.45;
+    margin-bottom: 0.6rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  // The stats used to sit in a separate .grid-25 column; now the content spans
+  // the full card width in a single column.
+  .grid-100 { width: 100%; }
+}
+
+// Card metadata + stats share one inline row of rounded pills. The metadata
+// pills (Uploaded, Format, …) are quiet light-grey chips; the stat pills
+// (classes / instances / projects / notes) use the same shape but lead with a
+// bold primary-color count and are clickable links to that section.
+.ont-meta-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.ont-stats {
+  display: contents; // let stat pills flow in the same flex row
+}
+
+.ont-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px; // fully rounded pill edges
+  background: var(--light-color);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  color: var(--gray-color);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  text-decoration: none;
+
+  b { color: #444; font-weight: 600; }
+
+  &.admin { background: var(--bg-info-light-color); }
+}
+
+// Stat pills: clickable, count-forward, with the count in brand color.
+a.ont-pill-stat {
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+
+  b { color: var(--primary-color); font-weight: 700; }
+
+  &:hover {
+    background: #e7eef5;
+    border-color: rgba(35, 73, 121, 0.25);
+  }
+}
+
+// Facet sidebar: quieter, uppercase section labels with a divider; consistent
+// control styling for the search box and selects.
+#facets {
+  // The legacy grid gave the facet column a 16px top margin, so the sidebar
+  // (and the Submit button at its top) started lower than the search toolbar in
+  // the adjacent column. Zero it so their top edges align.
+  margin-top: 0;
+
+  // "Submit Ontology" as the sidebar's clear primary action: a filled brand
+  // button with an upload glyph, instead of the empty outline box the shared
+  // secondary-button variant produced here (its icon slot wasn't rendering).
+  #upload-ontology-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    margin-bottom: 1.5rem;
+    padding: 0.6rem 1rem;
+    background-color: var(--primary-color) !important;
+    color: #fff !important;
+    border: 1px solid var(--primary-color) !important;
+    border-radius: 8px;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    transition: background-color 0.15s, box-shadow 0.15s;
+
+    &:hover {
+      background-color: var(--hover-color) !important;
+      border-color: var(--hover-color) !important;
+      box-shadow: 0 2px 6px rgba(35, 73, 121, 0.25);
+    }
+
+    // Upload glyph before the label (the component's own icon slot renders empty
+    // here, so we supply one via a masked background).
+    &::before {
+      content: "";
+      width: 16px;
+      height: 16px;
+      flex: 0 0 auto;
+      background-color: #fff;
+      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5'/%3E%3Cpath d='M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708z'/%3E%3C/svg%3E") no-repeat center / contain;
+      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5'/%3E%3Cpath d='M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708z'/%3E%3C/svg%3E") no-repeat center / contain;
+    }
+  }
+
+  // The facet groups sit together on one soft surface (like the toolbar and
+  // ontology cards) instead of each being its own bordered box. Groups are
+  // separated by light dividers rather than borders.
+  .facets-panel {
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 12px;
+    padding: 0.25rem 1rem 1rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  }
+
+  .facet {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    margin: 0 0 1.25rem 0;
+    padding-top: 1rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.07);
+
+    &:first-of-type {
+      border-top: none;
+      padding-top: 0.25rem;
+    }
+  }
+
+  .facet h4 {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #8a94a3;
+    font-weight: 700;
+    margin: 0 0 0.6rem 0;
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  // Facet rows: modern brand-accented checkbox, one per line, muted count.
+  .checkbox_list {
+    span[ng-repeat] { display: block; }
+    br { display: none; }
+
+    label {
+      display: inline;             // allow long facet names to wrap
+      white-space: normal;
+      font-size: 0.9rem;
+      color: #333;
+      cursor: pointer;
+      padding: 0.12rem 0;
+      line-height: 1.4;
+    }
+
+    input[type="checkbox"] {
+      width: 15px;
+      height: 15px;
+      accent-color: var(--primary-color);
+      margin-right: 0.5rem;
+      cursor: pointer;
+      vertical-align: middle;
+    }
+
+    .smaller { color: #9aa1ac; font-size: 0.8rem; margin-left: 0.25rem; }
+  }
+
+  .facet_disabled { opacity: 0.45; }
+
+  // The "Uploaded in the last" select matches the toolbar controls.
+  #upload_date_facet select {
+    width: 100%;
+    border: 1px solid #d8dee4;
+    border-radius: 8px;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.9rem;
+    background: #fff;
+  }
+}
+
+// The "View" tag on ontology-view cards: a quiet rounded pill above the title
+// (matching the metadata pills) instead of a heavy solid dark block floated
+// against the heading.
+#ontologies .ontology_view_badge {
+  float: none;
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0.35rem;
+  padding: 0.1rem 0.5rem;
+  background: var(--bg-info-light-color);
+  color: var(--primary-color);
+  border: 1px solid rgba(35, 73, 121, 0.25);
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  line-height: 1.4;
+}
+
+// Modern browse toolbar: one surface holding a prominent search on the left and
+// the result-count + sort + help grouped on the right. Replaces the old
+// loosely-floated controls that collapsed and overlapped the list.
+.browse-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.5rem;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+
+  #searching {
+    position: relative;
+    flex: 1 1 320px;   // grow to fill, wrap on narrow screens
+    margin: 0;
+  }
+
+  #sorting {
+    flex: 0 0 auto;
+    margin: 0;
+  }
+
+  #sorting_float {
+    float: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    white-space: nowrap;
+  }
+
+  #visible_ont_count {
+    padding: 0;
+    color: var(--gray-color);
+    font-size: 0.9rem;
+  }
+
+  #sorting label {
+    margin: 0;
+    color: var(--gray-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+
+  // Native select with a custom chevron so it matches the rounded controls.
+  #sorting select {
+    appearance: none;
+    -webkit-appearance: none;
+    border: 1px solid #d8dee4;
+    border-radius: 8px;
+    padding: 0.45rem 2rem 0.45rem 0.7rem;
+    background-color: #fff;
+    font-size: 0.9rem;
+    color: #333;
+    cursor: pointer;
+    background-repeat: no-repeat;
+    background-position: right 0.6rem center;
+    background-size: 0.7rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23666' viewBox='0 0 16 16'%3E%3Cpath d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3E%3C/svg%3E");
+
+    &:focus {
+      outline: none;
+      border-color: var(--primary-color);
+      box-shadow: 0 0 0 3px rgba(35, 73, 121, 0.12);
+    }
+  }
+}
+
+// Browse-help icon: a quiet, muted control that lives inline in the toolbar.
+.browse-help-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--gray-color);
+
+  &:hover { color: var(--primary-color); }
+}
+
+// The search field: the primary control — fills the toolbar's left side, with a
+// leading magnifier icon and a clear focus ring.
+.browse-toolbar #searching .search {
+  width: 100%;
+  font-size: 1rem;
+  padding: 0.55rem 0.9rem 0.55rem 2.4rem; // left room for the icon
+  border: 1px solid #d8dee4;
+  border-radius: 8px;
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-position: 0.8rem center;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23888' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E");
+  transition: border-color 0.15s, box-shadow 0.15s;
+
+  &::placeholder { color: #8a8a8a; }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(35, 73, 121, 0.12);
+  }
+}
+
+#sorting select,
+#upload_date_facet select {
+  border: 1px solid #ced4da;
+  border-radius: 6px;
+  padding: 0.3rem 0.5rem;
 }

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -556,6 +556,25 @@ $browse-gap: 24px;
   }
 }
 
+// "Show more" affordance below the rendered result window. Scrolling grows the
+// window automatically; this is the explicit fallback for the remaining rows.
+.ontology-list-more {
+  text-align: center;
+  padding: 0.5rem 0 1.5rem;
+
+  .ontology-list-more-btn {
+    border: 1px solid rgba(35, 73, 121, 0.25);
+    background: #fff;
+    color: var(--primary-color);
+    border-radius: 999px;
+    padding: 0.4rem 1.1rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+
+    &:hover { background: var(--bg-info-light-color); }
+  }
+}
+
 // Result count sits above the list (not in the toolbar). Quiet, slightly
 // indented to line up with the card content below.
 // Count + active-filter chips sit on one wrapping row above the list.

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -720,6 +720,38 @@ $browse-gap: 24px;
   white-space: nowrap;
 }
 
+// Lifecycle status pill beside the name — a quiet warning that an ontology is
+// no longer current. Retired reads as an error (red), deprecated as a caution
+// (amber). Sits next to the acronym pill and matches its size.
+.status-pill {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.12rem 0.55rem;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.status-pill.status-retired {
+  background: rgba(200, 45, 45, 0.1);
+  border: 1px solid rgba(200, 45, 45, 0.35);
+  color: #b3261e;
+}
+.status-pill.status-deprecated {
+  background: rgba(197, 134, 18, 0.12);
+  border: 1px solid rgba(197, 134, 18, 0.4);
+  color: #9a6a05;
+}
+
+// License pill in the metadata row — a subtle positive signal that access
+// terms are declared. Quiet green so it reads as "available" without competing
+// with the count pills.
+.ont-pill.ont-pill-license {
+  color: #2f7d54;
+}
+
 // Search-term highlight in result names/acronyms. Classic marker-yellow wash so
 // the matched substring reads like a highlighter pen; inherits the surrounding
 // text colour so link/pill text stays readable.

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -776,11 +776,21 @@ a.ont-pill.ont-pill-license {
 }
 
 // Inline "More"/"Less" toggle that expands the truncated description in place.
+// A real <button> (in-page expand, not navigation), reset to read as inline text.
+// appearance:none is required to strip the native button chrome (grey box +
+// bevel) that persists even with background/border cleared on some platforms.
 #ontologies .ont-description-toggle {
-  margin-left: 0.35rem;
+  appearance: none;
+  -webkit-appearance: none;
+  margin: 0 0 0 0.35rem;
+  padding: 0;
+  border: 0;
+  background: none;
   color: var(--primary-color);
+  font: inherit;
   font-size: 0.9em;
   font-weight: 600;
+  line-height: inherit;
   cursor: pointer;
 
   &:hover { text-decoration: underline; }
@@ -1187,10 +1197,4 @@ a.ont-pill-stat {
     border-color: var(--primary-color);
     box-shadow: 0 0 0 3px rgba(35, 73, 121, 0.12);
   }
-}
-
-#sorting select {
-  border: 1px solid #ced4da;
-  border-radius: 6px;
-  padding: 0.3rem 0.5rem;
 }

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -804,14 +804,24 @@ a.ont-pill-stat {
 
   .facet_disabled { opacity: 0.45; }
 
-  // The "Uploaded in the last" select matches the toolbar controls.
+  // The "Uploaded in the last" select matches the toolbar controls, including a
+  // custom chevron with room from the edge (the native caret sat cramped
+  // against the right border).
   #upload_date_facet select {
     width: 100%;
+    appearance: none;
+    -webkit-appearance: none;
     border: 1px solid #d8dee4;
     border-radius: 8px;
-    padding: 0.4rem 0.6rem;
+    padding: 0.4rem 2rem 0.4rem 0.6rem;
     font-size: 0.9rem;
-    background: #fff;
+    color: #333;
+    cursor: pointer;
+    background-color: #fff;
+    background-repeat: no-repeat;
+    background-position: right 0.7rem center;
+    background-size: 0.7rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23666' viewBox='0 0 16 16'%3E%3Cpath d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708'/%3E%3C/svg%3E");
   }
 }
 
@@ -960,8 +970,7 @@ a.ont-pill-stat {
   }
 }
 
-#sorting select,
-#upload_date_facet select {
+#sorting select {
   border: 1px solid #ced4da;
   border-radius: 6px;
   padding: 0.3rem 0.5rem;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -467,13 +467,16 @@ $bd-bottom-gap: 30px;
 // Rails/ViewComponent pages (Classes tab etc.): framed cards, flat light stat
 // pills, and a cleaner facet sidebar — without touching the Angular logic.
 
-// Loading splash shown (via [ng-cloak]) while the Angular app boots. Replace the
-// old grey box + big "Ontologies loading" text with a clean centered spinner and
-// quiet caption. Overrides the legacy .splash box in public/browse/app.css
-// (whose [ng-cloak].splash rule forces display:block !important, hence the
-// !important on display here).
-.ontologies.index div.splash,
-.splash,
+// Loading splash shown while the Angular app boots. AngularJS hides any element
+// carrying [ng-cloak] until it has finished bootstrapping, then strips the
+// attribute. The legacy public/browse/app.css relies on this: [ng-cloak].splash
+// forces the splash visible during boot, and plain .splash { display: none }
+// hides it once Angular removes the attribute.
+//
+// The styling below must therefore only apply while the element is STILL
+// cloaked ([ng-cloak].splash); a bare .splash rule with display:flex would keep
+// the splash on screen forever, since it wins after ng-cloak is stripped. We
+// leave the legacy .splash { display: none } in place to hide it post-boot.
 [ng-cloak].splash {
   width: auto !important;
   height: auto !important;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -730,6 +730,18 @@ $browse-gap: 24px;
   padding: 0 0.05em;
 }
 
+// Inline "More"/"Less" toggle that expands the truncated description in place.
+#ontologies .ont-description-toggle {
+  margin-left: 0.35rem;
+  color: var(--primary-color);
+  font-size: 0.9em;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover { text-decoration: underline; }
+}
+
 // Each ontology row as a clean, framed card that lifts on hover (the title is a
 // link, so the whole card reads as interactive).
 #ontologies .ontology.grid-parent {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -720,11 +720,11 @@ $browse-gap: 24px;
   white-space: nowrap;
 }
 
-// Search-term highlight in result names/acronyms. Soft gold wash (matching the
-// acronym pill family) so the matched substring stands out without shouting;
-// inherits the surrounding text colour so link/pill text stays readable.
+// Search-term highlight in result names/acronyms. Classic marker-yellow wash so
+// the matched substring reads like a highlighter pen; inherits the surrounding
+// text colour so link/pill text stays readable.
 #ontologies mark.search-hl {
-  background: rgba(197, 134, 18, 0.28);
+  background: #ffe94d;
   color: inherit;
   border-radius: 3px;
   padding: 0 0.05em;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -555,12 +555,68 @@ $browse-gap: 24px;
 
 // Result count sits above the list (not in the toolbar). Quiet, slightly
 // indented to line up with the card content below.
+// Count + active-filter chips sit on one wrapping row above the list.
+#ontologies .results-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  margin: 0 0 0.85rem 0.25rem;
+}
+
 #ontologies .results-count {
-  margin: 0 0 0.75rem 0.25rem;
   color: var(--gray-color);
   font-size: 0.9rem;
+  flex: 0 0 auto;
 
   b { color: #333; font-weight: 600; }
+}
+
+#ontologies .filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+// A removable filter chip: light pill, label + × affordance, hover to hint
+// removal.
+#ontologies .filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.35rem 0.15rem 0.6rem;
+  border: 1px solid rgba(35, 73, 121, 0.2);
+  border-radius: 999px;
+  background: var(--bg-info-light-color);
+  color: var(--primary-color);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  cursor: pointer;
+
+  .filter-chip-x {
+    font-size: 1rem;
+    line-height: 1;
+    color: var(--primary-color);
+    opacity: 0.6;
+  }
+
+  &:hover {
+    background: rgba(59, 130, 246, 0.16);
+    .filter-chip-x { opacity: 1; }
+  }
+}
+
+#ontologies .filter-clear-all {
+  border: none;
+  background: none;
+  padding: 0.15rem 0.25rem;
+  color: var(--gray-color);
+  font-size: 0.8rem;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover { color: var(--primary-color); }
 }
 
 .ontology.grid-parent h2 {
@@ -601,6 +657,24 @@ $browse-gap: 24px;
     margin: 0;
     font-size: 0.9rem;
     color: var(--gray-color);
+  }
+
+  .browse-empty-clear {
+    margin-top: 1.25rem;
+    padding: 0.45rem 1rem;
+    border: 1px solid var(--primary-color);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--primary-color);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+
+    &:hover {
+      background: var(--primary-color);
+      color: #fff;
+    }
   }
 }
 

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -967,12 +967,29 @@ a.ont-pill-stat {
     // line). The checkbox is positioned in a fixed left gutter; the label and
     // its count then flow inline, so the count sits right after the label name
     // — only wrapping with it if a name is genuinely too long for the column.
-    span[ng-repeat],
-    span.license-facet-row {
+    span[ng-repeat] {
       display: block;
       position: relative;
       width: auto;
       padding: 0.12rem 0 0.12rem 1.5rem; // left gutter for the checkbox
+    }
+
+    // The single "Has a license" toggle is a standalone row, not one of a list,
+    // so lay it out as a simple centered flex row rather than the absolute-gutter
+    // treatment used for the multi-line facet lists (which left the box sitting
+    // high against a single line of text).
+    span.license-facet-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      input[type="checkbox"] {
+        position: static;
+        top: auto;
+        flex: 0 0 auto;
+      }
+
+      label { line-height: 1; }
     }
 
     input[type="checkbox"] {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -467,6 +467,46 @@ $bd-bottom-gap: 30px;
 // Rails/ViewComponent pages (Classes tab etc.): framed cards, flat light stat
 // pills, and a cleaner facet sidebar — without touching the Angular logic.
 
+// Loading splash shown (via [ng-cloak]) while the Angular app boots. Replace the
+// old grey box + big "Ontologies loading" text with a clean centered spinner and
+// quiet caption. Overrides the legacy .splash box in public/browse/app.css
+// (whose [ng-cloak].splash rule forces display:block !important, hence the
+// !important on display here).
+.ontologies.index div.splash,
+.splash,
+[ng-cloak].splash {
+  width: auto !important;
+  height: auto !important;
+  margin: 5rem auto !important;
+  padding: 0 !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  display: flex !important;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--gray-color);
+
+  .splash-spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid rgba(35, 73, 121, 0.15);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: bp-splash-spin 0.8s linear infinite;
+  }
+
+  .splash-text {
+    margin: 1rem 0 0 0;
+    font-size: 0.95rem;
+    color: var(--gray-color);
+  }
+}
+
+@keyframes bp-splash-spin {
+  to { transform: rotate(360deg); }
+}
+
 // Bound the two-column browse area to the viewport and scroll each column
 // internally: the search/sort toolbar stays pinned, the facet sidebar stays in
 // place, and only the ontology list scrolls. $browse-top is the distance from

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -736,7 +736,6 @@ $browse-gap: 24px;
   color: var(--primary-color);
   font-size: 0.9em;
   font-weight: 600;
-  white-space: nowrap;
   cursor: pointer;
 
   &:hover { text-decoration: underline; }
@@ -764,17 +763,16 @@ $browse-gap: 24px;
     line-height: 1.3;
   }
 
-  // Description is secondary: muted, and clamped to two lines so every card
-  // keeps a consistent height regardless of how long/short the text is.
+  // Description is secondary: muted. Length is controlled by the
+  // descriptionSnippet filter (leading excerpt or match-centred window), and
+  // the "More" toggle expands the full text in place — so we must NOT clamp the
+  // height in CSS here (a -webkit-line-clamp both clipped the inline "More"
+  // link and would have re-truncated the expanded text).
   p {
     color: #5c6470;
     font-size: 0.9rem;
     line-height: 1.45;
     margin-bottom: 0.6rem;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
   }
 
   // The stats used to sit in a separate .grid-25 column; now the content spans

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -967,7 +967,8 @@ a.ont-pill-stat {
     // line). The checkbox is positioned in a fixed left gutter; the label and
     // its count then flow inline, so the count sits right after the label name
     // — only wrapping with it if a name is genuinely too long for the column.
-    span[ng-repeat] {
+    span[ng-repeat],
+    span.license-facet-row {
       display: block;
       position: relative;
       width: auto;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -748,8 +748,21 @@ $browse-gap: 24px;
 // License pill in the metadata row — a subtle positive signal that access
 // terms are declared. Quiet green so it reads as "available" without competing
 // with the count pills.
-.ont-pill.ont-pill-license {
+// License pill in the metadata row — a subtle positive signal that links to the
+// declared license (label derived from the URL, e.g. "CC BY 4.0"). Green-tinted
+// body so it reads as its own "available" category at a glance, without being
+// as loud as the retired/deprecated status pills.
+a.ont-pill.ont-pill-license {
   color: #2f7d54;
+  background: rgba(47, 125, 84, 0.09);
+  border-color: rgba(47, 125, 84, 0.28);
+  text-decoration: none;
+
+  &:hover {
+    color: #235c3e;
+    background: rgba(47, 125, 84, 0.16);
+    border-color: rgba(47, 125, 84, 0.5);
+  }
 }
 
 // Search-term highlight in result names/acronyms. Classic marker-yellow wash so

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -481,6 +481,12 @@ $browse-gap: 24px;
   box-sizing: border-box;
 }
 
+// Widen the facet column past the legacy grid-20/80 split so facet labels and
+// their counts (e.g. "Human Developmental Anatomy (46)") fit without the count
+// orphaning onto its own line.
+#facets.grid-20 { width: 30%; }
+#ontologies.grid-80 { width: 70%; }
+
 // Facet sidebar scrolls on its own when it's taller than the viewport. A little
 // right padding keeps the scrollbar off the panel edge.
 #facets {
@@ -505,6 +511,16 @@ $browse-gap: 24px;
     overscroll-behavior: contain;
     padding-right: 1rem;
   }
+}
+
+// Result count sits above the list (not in the toolbar). Quiet, slightly
+// indented to line up with the card content below.
+#ontologies .results-count {
+  margin: 0 0 0.75rem 0.25rem;
+  color: var(--gray-color);
+  font-size: 0.9rem;
+
+  b { color: #333; font-weight: 600; }
 }
 
 .ontology.grid-parent h2 {
@@ -640,15 +656,17 @@ a.ont-pill-stat {
     }
 
     // Upload glyph before the label (the component's own icon slot renders empty
-    // here, so we supply one via a masked background).
+    // here, so we supply one via a masked background). A bolder, heavier-stroke
+    // upload icon so it doesn't look thin next to the bold label.
     &::before {
       content: "";
-      width: 16px;
-      height: 16px;
+      width: 18px;
+      height: 18px;
       flex: 0 0 auto;
       background-color: #fff;
-      mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5'/%3E%3Cpath d='M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708z'/%3E%3C/svg%3E") no-repeat center / contain;
-      -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath d='M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5'/%3E%3Cpath d='M7.646 1.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1-.708.708L8.5 2.707V11.5a.5.5 0 0 1-1 0V2.707L5.354 4.854a.5.5 0 1 1-.708-.708z'/%3E%3C/svg%3E") no-repeat center / contain;
+      $upload-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2'/%3E%3Cpath d='M12 15V3'/%3E%3Cpath d='m7 8 5-5 5 5'/%3E%3C/svg%3E");
+      mask: $upload-icon no-repeat center / contain;
+      -webkit-mask: $upload-icon no-repeat center / contain;
     }
   }
 
@@ -690,29 +708,47 @@ a.ont-pill-stat {
 
   // Facet rows: modern brand-accented checkbox, one per line, muted count.
   .checkbox_list {
-    span[ng-repeat] { display: block; }
     br { display: none; }
 
+    // Each facet row fills the full column width (it previously shrink-wrapped,
+    // which forced labels to wrap early and dropped the count onto its own
+    // line). The checkbox is positioned in a fixed left gutter; the label and
+    // its count then flow inline, so the count sits right after the label name
+    // — only wrapping with it if a name is genuinely too long for the column.
+    span[ng-repeat] {
+      display: block;
+      position: relative;
+      width: auto;
+      padding: 0.12rem 0 0.12rem 1.5rem; // left gutter for the checkbox
+    }
+
+    input[type="checkbox"] {
+      position: absolute;
+      left: 0;
+      top: 0.28rem;
+      width: 15px;
+      height: 15px;
+      accent-color: var(--primary-color);
+      margin: 0;
+      cursor: pointer;
+    }
+
     label {
-      display: inline;             // allow long facet names to wrap
+      display: inline;
       white-space: normal;
       font-size: 0.9rem;
       color: #333;
       cursor: pointer;
-      padding: 0.12rem 0;
       line-height: 1.4;
+      margin: 0;
     }
 
-    input[type="checkbox"] {
-      width: 15px;
-      height: 15px;
-      accent-color: var(--primary-color);
-      margin-right: 0.5rem;
-      cursor: pointer;
-      vertical-align: middle;
+    .smaller {
+      margin-left: 0.3rem;
+      color: #9aa1ac;
+      font-size: 0.8rem;
+      white-space: nowrap; // keep "(21)" itself from breaking
     }
-
-    .smaller { color: #9aa1ac; font-size: 0.8rem; margin-left: 0.25rem; }
   }
 
   .facet_disabled { opacity: 0.45; }
@@ -758,20 +794,37 @@ a.ont-pill-stat {
   flex-wrap: wrap;
   padding: 0.75rem 1rem;
   margin-bottom: 1.5rem;
-  background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.1);
+  // Match the toolbar band to the site header / Submit button (--primary-color)
+  // so the page reads as one coherent blue rather than clashing shades. The
+  // search field and select stay white (below) so they read clearly as controls.
+  background: var(--primary-color);
+  border: 1px solid var(--primary-color);
   border-radius: 12px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 2px 6px rgba(35, 73, 121, 0.2);
 
+  // On the dark band, the sort label and help icon go light.
+  #sorting label { color: rgba(255, 255, 255, 0.9); }
+  .browse-help-link {
+    color: rgba(255, 255, 255, 0.85);
+    &:hover { color: #fff; }
+  }
+
+  // The toolbar centers its items (align-items: center above); make the two
+  // wrappers flex too so the search field and the sort select share a common
+  // vertical centerline regardless of their slightly different heights.
   #searching {
     position: relative;
     flex: 1 1 320px;   // grow to fill, wrap on narrow screens
     margin: 0;
+    display: flex;
+    align-items: center;
   }
 
   #sorting {
     flex: 0 0 auto;
     margin: 0;
+    display: flex;
+    align-items: center;
   }
 
   #sorting_float {
@@ -780,6 +833,7 @@ a.ont-pill-stat {
     align-items: center;
     gap: 0.6rem;
     white-space: nowrap;
+    margin: 0; // clear a legacy 8px bottom margin that pushed the select off-centre
   }
 
   #visible_ont_count {
@@ -796,10 +850,13 @@ a.ont-pill-stat {
   }
 
   // Native select with a custom chevron so it matches the rounded controls.
+  // Borderless white on the blue band; height matched to the search field so
+  // the two controls share a centerline.
   #sorting select {
     appearance: none;
     -webkit-appearance: none;
-    border: 1px solid #d8dee4;
+    height: 44px;
+    border: 1px solid transparent;
     border-radius: 8px;
     padding: 0.45rem 2rem 0.45rem 0.7rem;
     background-color: #fff;
@@ -832,9 +889,10 @@ a.ont-pill-stat {
 // leading magnifier icon and a clear focus ring.
 .browse-toolbar #searching .search {
   width: 100%;
+  margin: 0; // clear a legacy -5px top margin that pushed it above the select
   font-size: 1rem;
   padding: 0.55rem 0.9rem 0.55rem 2.4rem; // left room for the icon
-  border: 1px solid #d8dee4;
+  border: 1px solid transparent; // white field reads cleanly on the blue band
   border-radius: 8px;
   background-color: #fff;
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -533,6 +533,57 @@ $browse-gap: 24px;
   }
 }
 
+// Empty state when no ontologies match: a calm, centered message with a muted
+// search icon — no boxed border, no exclamation mark.
+.browse-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 4rem 1rem;
+  color: var(--gray-color);
+
+  .browse-empty-icon {
+    width: 44px;
+    height: 44px;
+    color: #c2c8d0;
+    margin-bottom: 1rem;
+  }
+
+  .browse-empty-title {
+    margin: 0 0 0.35rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #444;
+  }
+
+  .browse-empty-text {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--gray-color);
+  }
+}
+
+// The ontology acronym, pulled out of the "(…)" in the title into a small
+// identifier pill beside the name. Ontologies are often known by acronym
+// (SNOMEDCT, MESH, LOINC), so a distinct, scannable tag helps. It uses the
+// Login-button gold (--login-btn-color) as a warm second accent against the
+// page's blue.
+.acronym-pill {
+  display: inline-block;
+  margin-left: 0.55rem;
+  padding: 0.12rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(197, 134, 18, 0.1);
+  border: 1px solid rgba(197, 134, 18, 0.35);
+  color: var(--login-btn-color);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 // Each ontology row as a clean, framed card that lifts on hover (the title is a
 // link, so the whole card reads as interactive).
 #ontologies .ontology.grid-parent {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -760,6 +760,11 @@ $browse-gap: 24px;
   border: 1px solid rgba(197, 134, 18, 0.4);
   color: #9a6a05;
 }
+.status-pill.status-private {
+  background: rgba(154, 59, 90, 0.10);
+  border: 1px solid rgba(154, 59, 90, 0.38);
+  color: #9a3b5a;
+}
 
 // License pill in the metadata row — a subtle positive signal that access
 // terms are declared. Quiet green so it reads as "available" without competing
@@ -915,6 +920,23 @@ a.ont-pill-stat {
   }
 }
 
+// Projects and notes are community/activity counts, not ontology content
+// (classes/instances). Give them a distinctly lighter, outline-style pill — a
+// white body with a defined grey border and grey number — so they read as
+// clearly secondary next to the tinted, navy-numbered content-count pills.
+a.ont-pill-stat.ont-pill-muted {
+  background: #fff;
+  border-color: rgba(0, 0, 0, 0.18);
+  color: var(--gray-color);
+
+  b { color: #6b7280; font-weight: 600; }
+
+  &:hover {
+    background: #f4f4f5;
+    border-color: rgba(0, 0, 0, 0.28);
+  }
+}
+
 // Facet sidebar: quieter, uppercase section labels with a divider; consistent
 // control styling for the search box and selects.
 #facets {
@@ -1024,6 +1046,7 @@ a.ont-pill-stat {
       display: flex;
       align-items: center;
       gap: 0.5rem;
+      padding: 0.18rem 0; // vertical breathing room so stacked toggles don't touch
 
       input[type="checkbox"] {
         position: static;
@@ -1031,7 +1054,7 @@ a.ont-pill-stat {
         flex: 0 0 auto;
       }
 
-      label { line-height: 1; }
+      label { line-height: 1.2; }
     }
 
     input[type="checkbox"] {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -752,16 +752,18 @@ $browse-gap: 24px;
 // declared license (label derived from the URL, e.g. "CC BY 4.0"). Green-tinted
 // body so it reads as its own "available" category at a glance, without being
 // as loud as the retired/deprecated status pills.
+// License pill uses a deep-purple tint — its own accent, distinct from the green
+// admin-only pills, the gold acronym pills, and the navy UI.
 a.ont-pill.ont-pill-license {
-  color: #2f7d54;
-  background: rgba(47, 125, 84, 0.09);
-  border-color: rgba(47, 125, 84, 0.28);
+  color: #6d3f9e;
+  background: rgba(109, 63, 158, 0.10);
+  border-color: rgba(109, 63, 158, 0.32);
   text-decoration: none;
 
   &:hover {
-    color: #235c3e;
-    background: rgba(47, 125, 84, 0.16);
-    border-color: rgba(47, 125, 84, 0.5);
+    color: #58318a;
+    background: rgba(109, 63, 158, 0.18);
+    border-color: rgba(109, 63, 158, 0.5);
   }
 }
 
@@ -847,8 +849,22 @@ a.ont-pill.ont-pill-license {
   margin-top: 0.5rem;
 }
 
-.ont-stats {
-  display: contents; // let stat pills flow in the same flex row
+// Ontology metrics sit on their own second row, below the upload/license line.
+.ont-stat-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
+// Admin-only pills sit on their own row below the public metadata/stats.
+.ont-admin-pills {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
 }
 
 .ont-pill {

--- a/app/assets/stylesheets/ontologies.scss
+++ b/app/assets/stylesheets/ontologies.scss
@@ -524,6 +524,22 @@ $browse-gap: 24px;
   box-sizing: border-box;
 }
 
+// The admin "Welcome admin" notice carries legacy positioning hacks
+// (float:right; position:relative; top:-5em; left:-33%; width:33%) meant for
+// the old Browse layout. In the redesigned two-column layout that float pushes
+// the results column (and its search toolbar) down and misaligns the columns.
+// Reset it to a normal-flow, full-width notice above the columns.
+#ontologies-page .welcome_admin,
+.ontologies.index .welcome_admin,
+[ng-controller="OntologyList"] > .welcome_admin {
+  float: none;
+  position: static;
+  top: auto;
+  left: auto;
+  width: auto;
+  margin: 0 0 0.75rem 0;
+}
+
 // Widen the facet column past the legacy grid-20/80 split so facet labels and
 // their counts (e.g. "Human Developmental Anatomy (46)") fit without the count
 // orphaning onto its own line.

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -35,7 +35,7 @@ class OntologiesController < ApplicationController
     # toggled on in production.
     @development = Rails.env.development? && params[:debug].present?
 
-    submissions = LinkedData::Client::Models::OntologySubmission.all(include_views: true, display_links: false, display_context: false, include: 'submissionStatus,hasOntologyLanguage,pullLocation,description,creationDate,status')
+    submissions = LinkedData::Client::Models::OntologySubmission.all(include_views: true, display_links: false, display_context: false, include: 'submissionStatus,hasOntologyLanguage,pullLocation,description,creationDate,status,hasLicense')
     submissions_map = submissions.each_with_object({}) do |sub, h|
       ontology_id = sub.id.sub(%r{/submissions/[^/]+$}, '')
       if (ontology = ontologies_hash[ontology_id])
@@ -108,6 +108,10 @@ class OntologiesController < ApplicationController
         o[:description]               = sub.description
         o[:creationDate]              = sub.creationDate
         o[:submissionStatusFormatted] = submission_status2string(sub)
+        # Lifecycle status ('retired' / 'deprecated') and whether the submission
+        # declares a license — surfaced as pills on the browse card.
+        o[:status]                    = sub.status
+        o[:hasLicense]                = sub.hasLicense.present?
 
         o[:format] = sub.hasOntologyLanguage
         @formats << sub.hasOntologyLanguage

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -35,7 +35,7 @@ class OntologiesController < ApplicationController
     # toggled on in production.
     @development = Rails.env.development? && params[:debug].present?
 
-    submissions = LinkedData::Client::Models::OntologySubmission.all(include_views: true, display_links: false, display_context: false, include: 'submissionStatus,hasOntologyLanguage,pullLocation,description,creationDate,status,hasLicense')
+    submissions = LinkedData::Client::Models::OntologySubmission.all(include_views: true, display_links: false, display_context: false, include: 'submissionStatus,hasOntologyLanguage,pullLocation,description,creationDate,status,hasLicense,keywords')
     submissions_map = submissions.each_with_object({}) do |sub, h|
       ontology_id = sub.id.sub(%r{/submissions/[^/]+$}, '')
       if (ontology = ontologies_hash[ontology_id])
@@ -107,6 +107,9 @@ class OntologiesController < ApplicationController
         o[:pullLocation]              = sub.pullLocation
         o[:description]               = sub.description
         o[:creationDate]              = sub.creationDate
+        # Self-declared keywords (sparsely populated) — not displayed, but folded
+        # into the client-side search index so a keyword match surfaces the ontology.
+        o[:keywords]                  = Array(sub.keywords).join(' ')
         o[:submissionStatusFormatted] = submission_status2string(sub)
         # Lifecycle status ('retired' / 'deprecated') and the submission's
         # license URL (if any) — surfaced as pills on the browse card. The

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -108,9 +108,11 @@ class OntologiesController < ApplicationController
         o[:description]               = sub.description
         o[:creationDate]              = sub.creationDate
         o[:submissionStatusFormatted] = submission_status2string(sub)
-        # Lifecycle status ('retired' / 'deprecated') and whether the submission
-        # declares a license — surfaced as pills on the browse card.
+        # Lifecycle status ('retired' / 'deprecated') and the submission's
+        # license URL (if any) — surfaced as pills on the browse card. The
+        # license is a URL; the template derives a short human label from it.
         o[:status]                    = sub.status
+        o[:license]                   = sub.hasLicense.presence
         o[:hasLicense]                = sub.hasLicense.present?
 
         o[:format] = sub.hasOntologyLanguage

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -29,7 +29,11 @@ class OntologiesController < ApplicationController
     ontologies = LinkedData::Client::Models::Ontology.all(include: LinkedData::Client::Models::Ontology.include_params + ',viewOf', include_views: true, display_context: false)
     ontologies_hash = Hash[ontologies.map { |o| [o.id, o] }]
     @admin = session[:user] ? session[:user].admin? : false
-    @development = Rails.env.development?
+    # Drives the browse page's debug UI (Debug Info panel + result numbering).
+    # Opt-in via ?debug=1 rather than always-on in development, so the dev view
+    # normally matches production. Restricted to development so it can't be
+    # toggled on in production.
+    @development = Rails.env.development? && params[:debug].present?
 
     submissions = LinkedData::Client::Models::OntologySubmission.all(include_views: true, display_links: false, display_context: false, include: 'submissionStatus,hasOntologyLanguage,pullLocation,description,creationDate,status')
     submissions_map = submissions.each_with_object({}) do |sub, h|

--- a/app/controllers/ontologies_controller.rb
+++ b/app/controllers/ontologies_controller.rb
@@ -63,12 +63,15 @@ class OntologiesController < ApplicationController
       if metrics_hash[ont.id]
         o[:class_count] = metrics_hash[ont.id].classes
         o[:individual_count] = metrics_hash[ont.id].individuals
+        o[:property_count] = metrics_hash[ont.id].properties
       else
         o[:class_count] = 0
         o[:individual_count] = 0
+        o[:property_count] = 0
       end
       o[:class_count_formatted] = number_with_delimiter(o[:class_count], delimiter: ',')
       o[:individual_count_formatted] = number_with_delimiter(o[:individual_count], delimiter: ',')
+      o[:property_count_formatted] = number_with_delimiter(o[:property_count], delimiter: ',')
 
       o[:id]               = ont.id
       o[:type]             = ont.viewOf.nil? ? 'ontology' : 'ontology_view'

--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -66,7 +66,10 @@
   <script src="lib/html5-boilerplate/js/vendor/modernizr-2.6.2.min.js"></script>
   <script src="lib/angular-bindonce/bindonce.min.js"></script>
   <script src="checklist-model.js"></script>
-  <script src="app.js"></script>
+  <%# Cache-bust the static Angular bundle by its file mtime so browsers pick up
+      changes without a manual version bump. %>
+  <% app_js_path = Rails.root.join('public', 'browse', 'app.js') %>
+  <script src="app.js?v=<%= (File.mtime(app_js_path).to_i rescue Rails.application.config.assets.version) %>"></script>
 
   <% if appliance_mode %>
     <%= render partial: "footer_appliance" %>

--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -59,10 +59,8 @@
   <!-- Angular JS, loaded from CDN unless you need otherwise -->
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.5/angular.min.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.5/angular-route.min.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.5/angular-animate.min.js"></script>
   <!-- <script src="lib/angular/angular.js"></script> -->
   <!-- <script src="lib/angular-route/angular-route.js"></script> -->
-  <!-- <script src="lib/angular-animate/angular-animate.min.js"></script> -->
 
   <script src="lib/html5-boilerplate/js/vendor/modernizr-2.6.2.min.js"></script>
   <script src="lib/angular-bindonce/bindonce.min.js"></script>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -65,6 +65,7 @@
         </div>
 
         <div id="license_facet" class="facet">
+          <h4>License</h4>
           <div class="checkbox_list">
             <span class="license-facet-row">
               <input type="checkbox" id="has_license" ng-model="facets.has_license.active" ng-true-value="'yes'" ng-false-value="''">
@@ -226,9 +227,10 @@
             <div ng-if="ontology.submission">
               <p class="ont-description" style="margin-bottom: 5px;"><%#
                 %><span ng-bind-html="ontology.description | descriptionSnippet:searchText:ontology._descExpanded | highlight:searchText"></span><%#
-                %> <a href="" class="ont-description-toggle" ng-if="descriptionHasMore(ontology)"
-                     ng-click="$event.preventDefault(); ontology._descExpanded = !ontology._descExpanded"><%#
-                  %>{{ontology._descExpanded ? 'Less' : 'More'}}</a><%#
+                %> <button type="button" class="ont-description-toggle" ng-if="descriptionHasMore(ontology)"
+                     ng-click="ontology._descExpanded = !ontology._descExpanded"
+                     aria-expanded="{{ontology._descExpanded ? 'true' : 'false'}}"><%#
+                  %>{{ontology._descExpanded ? 'Less' : 'More'}}</button><%#
               %></p>
 
               <%# Metadata + stats as one inline row of rounded pills %>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -173,7 +173,7 @@
           <p class="browse-empty-text">Try a different search term or clear some filters.</p>
         </div>
 
-        <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontology_sort_order" ng-if="ontology.show">
+        <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontologySortValue:(ontology_sort_order.charAt(0) === '-')" ng-if="ontology.show">
           <div class="grid-100">
             <div ng-if="ontology.type == 'ontology_view'" class="ontology_view_badge" title="This ontology is a view of {{ontology.viewOfOnt.name}}">VIEW</div>
             <h2 style="font-size: 1.5em;">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -14,16 +14,9 @@
   </div>
 
   <div class="grid-container" style="margin-bottom: 1em; margin-top: 1em;" ng-cloak>
-    <h1 style="font-size: 3em;">Browse</h1>
-    <p>
-      <%= t('ontologies.intro').html_safe %>
-      <%= link_to(Rails.configuration.settings.links[:help_ontology_browse],
-                  data: {controller: 'popup', action: 'click->popup#open'},
-                  'aria-label': 'View ontology browse help') do %>
-        <%= inline_svg_tag 'icons/question-circle.svg', class: 'svg-icon svg-icon-lg ps-1', aria_hidden: true %>
-      <% end %>
-    </p>
-
+    <%# The "Browse" heading + intro subtitle were redundant (the nav already
+        labels this page and the list is self-evident) and pushed content down.
+        Removed; the browse-help link now lives in the search/sort toolbar. %>
     <div ng-controller="OntologyList">
       <div class="welcome_admin admin" ng-show="admin">
         <b>Welcome admin</b><br/>This coloring indicates admin-only features
@@ -44,6 +37,8 @@
           <%= upload_ontology_button %>
         </div>
 
+        <%# All facet groups share one soft panel (styled in ontologies.scss). %>
+        <div class="facets-panel">
         <div id="ont_view_facet" class="facet">
           <h4>Entry Type</h4>
           <div class="checkbox_list">
@@ -127,31 +122,43 @@
             </span>
           </div>
         </div>
+        </div><%# /.facets-panel %>
 
       </div>
 
       <div id="ontologies" class="grid-80">
-        <div id="searching">
-          <input type="text" placeholder="Search&hellip;" ng-model="searchText" ng-model-options="{debounce: 100}" class="search">
-        </div>
+        <div class="browse-toolbar">
+          <div id="searching">
+            <input type="text" placeholder="Search ontologies&hellip;" ng-model="searchText" ng-model-options="{debounce: 100}" class="search">
+          </div>
 
-        <div id="sorting" ng-show="visible_ont_count" style="margin-bottom: 2em;">
-          <div id="sorting_float">
-            <span style="padding: 7px 7px 4px;" id="visible_ont_count">Showing {{visible_ont_count}} of {{ontologies.length}}</span>
-            <label for="sort_order">Sort:</label>
-            <select ng-model="ontology_sort_order">
-              <option value="-popularity" selected="selected">Popular</option>
-              <option value="name">Name</option>
-              <option value="-class_count">Classes count</option>
-              <option value="-individual_count">Instances/Concepts count</option>
-              <option value="-project_count">Projects</option>
-              <option value="-note_count">Notes</option>
-              <option value="-creationDate">Upload Date</option>
-              <option value="-search_rank" ng-show="searchText.length > 0">Search Rank</option>
-            </select>
+          <div id="sorting" ng-show="visible_ont_count">
+            <div id="sorting_float">
+              <span id="visible_ont_count">{{visible_ont_count}} of {{ontologies.length}}</span>
+              <label for="sort_order">Sort</label>
+              <select ng-model="ontology_sort_order">
+                <option value="-popularity" selected="selected">Popular</option>
+                <option value="name">Name</option>
+                <option value="-class_count">Classes count</option>
+                <option value="-individual_count">Instances/Concepts count</option>
+                <option value="-project_count">Projects</option>
+                <option value="-note_count">Notes</option>
+                <option value="-creationDate">Upload Date</option>
+                <option value="-search_rank" ng-show="searchText.length > 0">Search Rank</option>
+              </select>
+              <%= link_to(Rails.configuration.settings.links[:help_ontology_browse],
+                          class: 'browse-help-link',
+                          data: {controller: 'popup', action: 'click->popup#open'},
+                          'aria-label': 'View ontology browse help') do %>
+                <%= inline_svg_tag 'icons/question-circle.svg', class: 'svg-icon svg-icon-lg', aria_hidden: true %>
+              <% end %>
+            </div>
           </div>
         </div>
 
+        <%# The ontology cards scroll independently below the (pinned) toolbar,
+            so the toolbar and the facet sidebar stay in place while browsing. %>
+        <div class="ontology-list">
         <div class="ontology" ng-show="visible_ont_count == 0" style="border: solid thin lightGray;">
           <div style="text-align: center; color: gray; height: 2em; padding: 4em;">
             <h2 style="font-weight: normal;">No matches!</h2>
@@ -159,7 +166,7 @@
         </div>
 
         <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontology_sort_order" ng-if="ontology.show">
-          <div class="grid-75">
+          <div class="grid-100">
             <div ng-if="ontology.type == 'ontology_view'" class="ontology_view_badge" title="This ontology is a view of {{ontology.viewOfOnt.name}}">VIEW</div>
             <h2 style="font-size: 1.5em;">
               <a href="/ontologies/{{ontology.acronym}}">
@@ -170,79 +177,57 @@
             </h2>
             <div ng-if="ontology.submission">
               <p style="margin-bottom: 5px;">{{ontology.description | descriptionToText}}</p>
-              <span class="ont-info">
-                <b>Uploaded</b>: {{ontology.creationDate | date:'shortDate'}}
-              </span>
-              <span class="ont-info" ng-if="facets.formats.active.length > 1">
-                <b>Format</b>: {{ontology.format}}
-              </span>
-              <span class="ont-info" ng-if="ontology.type == 'ontology_view'">
-                <b>View of</b>: <a href="/ontologies/{{ontology.viewOfOnt.acronym}}">{{ontology.viewOfOnt.acronym}}</a>
-              </span>
-              <span class="ont-info" ng-if="ontology.summaryOnly">
-                <b>Summary Only</b>
-              </span>
-              <span class="ont-info" ng-if="facets.groups.active.length > 1">
-                <b>Groups</b>: {{groupAcronyms(ontology.groups).join(', ')}}
-              </span>
-              <span class="ont-info" ng-if="facets.categories.active.length > 1">
-                <b>Categories</b>: {{categoryNames(ontology.categories).join(', ')}}
-              </span>
-              <span>
-                <span class="ont-info admin" ng-if="admin">
-                  <b>Admins</b>: {{adminUsernames(ontology.administeredBy).join(', ')}}
+
+              <%# Metadata + stats as one inline row of rounded pills %>
+              <div class="ont-meta-pills">
+                <span class="ont-pill">
+                  <b>Uploaded</b> {{ontology.creationDate | date:'shortDate'}}
                 </span>
-                <span class="ont-info admin" ng-if="admin && ontology.pullLocation">
-                  <b><a href="{{ontology.pullLocation}}">Pull URL</a></b>
+                <span class="ont-pill" ng-if="facets.formats.active.length > 1">
+                  <b>Format</b> {{ontology.format}}
                 </span>
-                <span class="ont-info admin" ng-if="admin && ontology.submission">
-                  <b>Status</b>: {{ontology.submissionStatusFormatted}}
+                <span class="ont-pill" ng-if="ontology.type == 'ontology_view'">
+                  <b>View of</b> <a href="/ontologies/{{ontology.viewOfOnt.acronym}}">{{ontology.viewOfOnt.acronym}}</a>
                 </span>
-              </span>
+                <span class="ont-pill" ng-if="ontology.summaryOnly">Summary Only</span>
+                <span class="ont-pill" ng-if="facets.groups.active.length > 1">
+                  <b>Groups</b> {{groupAcronyms(ontology.groups).join(', ')}}
+                </span>
+                <span class="ont-pill" ng-if="facets.categories.active.length > 1">
+                  <b>Categories</b> {{categoryNames(ontology.categories).join(', ')}}
+                </span>
+                <span class="ont-pill admin" ng-if="admin">
+                  <b>Admins</b> {{adminUsernames(ontology.administeredBy).join(', ')}}
+                </span>
+                <span class="ont-pill admin" ng-if="admin && ontology.pullLocation">
+                  <a href="{{ontology.pullLocation}}">Pull URL</a>
+                </span>
+                <span class="ont-pill admin" ng-if="admin && ontology.submission">
+                  <b>Status</b> {{ontology.submissionStatusFormatted}}
+                </span>
+
+                <%# Stat pills — same pill styling, count-forward, links to the section %>
+                <span class="ont-stats" ng-if="ontology.submission !== null && ontology.class_count > 0">
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
+                    <b>{{ontology.class_count_formatted}}</b> classes
+                  </a>
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
+                    <b>{{ontology.individual_count_formatted}}</b> {{ontology.format === 'SKOS' ? "concepts" : "instances"}}
+                  </a>
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
+                    <b>{{ontology.projects.length}}</b> projects
+                  </a>
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
+                    <b>{{ontology.notes.length}}</b> notes
+                  </a>
+                </span>
+              </div>
             </div>
 
             <span ng-hide="ontology.submission">No submissions available</span>
           </div>
-
-          <div class="badges grid-25 grid-parent" ng-if="ontology.submission !== null && ontology.class_count > 0">
-            <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
-              <div class="grid-50 badge_grid">
-                <div class="ontology_badge">
-                  <div class="badge_title">classes</div>
-                  <div class="badge_count">{{ontology.class_count_formatted}}</div>
-                </div>
-              </div>
-            </a>
-
-            <a href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0 ">
-              <div class="grid-50 badge_grid">
-                <div class="ontology_badge">
-                  <div class="badge_title">{{ontology.format === 'SKOS' ? "concepts" : "instances"}}</div>
-                  <div class="badge_count">{{ontology.individual_count_formatted}}</div>
-                </div>
-              </div>
-            </a>
-
-            <a href="/ontologies/{{ontology.acronym}}#projects_content">
-              <div class="grid-50 badge_grid" ng-if="ontology.projects.length > 0">
-                <div class="ontology_badge">
-                  <div class="badge_title">projects</div>
-                  <div class="badge_count">{{ontology.projects.length}}</div>
-                </div>
-              </div>
-            </a>
-
-            <a href="/ontologies/{{ontology.acronym}}?p=notes">
-              <div class="grid-50 badge_grid" ng-if="ontology.notes.length > 0">
-                <div class="ontology_badge">
-                  <div class="badge_title">notes</div>
-                  <div class="badge_count">{{ontology.notes.length}}</div>
-                </div>
-              </div>
-            </a>
-
-          </div>
         </div>
+        </div><%# /.ontology-list %>
       </div>
     </div>
   </div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -129,7 +129,7 @@
       <div id="ontologies" class="grid-80">
         <div class="browse-toolbar">
           <div id="searching">
-            <input type="text" placeholder="Search ontologies&hellip;" ng-model="searchText" ng-model-options="{debounce: 300}" class="search">
+            <input type="text" id="ontology_search" placeholder="Search ontologies&hellip;" ng-model="searchText" ng-model-options="{debounce: 300}" class="search">
           </div>
 
           <div id="sorting" ng-show="visible_ont_count">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -134,7 +134,6 @@
 
           <div id="sorting" ng-show="visible_ont_count">
             <div id="sorting_float">
-              <span id="visible_ont_count">{{visible_ont_count}} of {{ontologies.length}}</span>
               <label for="sort_order">Sort</label>
               <select ng-model="ontology_sort_order">
                 <option value="-popularity" selected="selected">Popular</option>
@@ -154,6 +153,11 @@
               <% end %>
             </div>
           </div>
+        </div>
+
+        <%# Result count sits just above the list, not in the search/sort bar. %>
+        <div id="visible_ont_count" class="results-count" ng-show="visible_ont_count">
+          <b>{{visible_ont_count}}</b> of {{ontologies.length}} ontologies
         </div>
 
         <%# The ontology cards scroll independently below the (pinned) toolbar,

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -189,30 +189,42 @@
           <button type="button" class="browse-empty-clear" ng-if="hasActiveFilters()" ng-click="clearAllFilters()">Clear all filters</button>
         </div>
 
-        <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontologySortValue:(ontology_sort_order.charAt(0) === '-')" ng-if="ontology.show">
+        <%# Performance: only build DOM for ontologies that actually match the
+            current search + facets (filter:onlyShown), sorted, and capped to the
+            first `render_limit` rows (grown on scroll — see growRenderLimit).
+            Previously ng-repeat rendered ALL ~1,500 ontologies and hid the
+            non-matching ones with ng-if, so every digest reconciled thousands of
+            DOM nodes and watchers — the source of the typing stutter.
+
+            `track by ontology.id` lets ng-repeat reuse DOM rows across re-sorts
+            instead of tearing them down and rebuilding (which had also been
+            duplicating rows). Static card content uses one-time bindings (::)
+            since an ontology's name/description/counts never change after load. %>
+        <div class="ontology grid-parent clearfix"
+             ng-repeat="ontology in filteredOntologies | limitTo:render_limit track by ontology.id">
           <div class="grid-100">
-            <div ng-if="ontology.type == 'ontology_view'" class="ontology_view_badge" title="This ontology is a view of {{ontology.viewOfOnt.name}}">VIEW</div>
+            <div ng-if="ontology.type == 'ontology_view'" class="ontology_view_badge" title="This ontology is a view of {{::ontology.viewOfOnt.name}}">VIEW</div>
             <h2 style="font-size: 1.5em;">
-              <a href="/ontologies/{{ontology.acronym}}">
+              <a href="/ontologies/{{::ontology.acronym}}">
                 <span ng-if="debug">{{$index}} </span>
-                {{ontology.name}}
+                {{::ontology.name}}
               </a>
-              <span class="acronym-pill">{{ontology.acronym}}</span>
+              <span class="acronym-pill">{{::ontology.acronym}}</span>
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">
-              <p style="margin-bottom: 5px;">{{ontology.description | descriptionToText}}</p>
+              <p style="margin-bottom: 5px;">{{::ontology.description | descriptionToText}}</p>
 
               <%# Metadata + stats as one inline row of rounded pills %>
               <div class="ont-meta-pills">
                 <span class="ont-pill">
-                  <b>Uploaded</b> {{ontology.creationDate | date:'shortDate'}}
+                  <b>Uploaded</b> {{::ontology.creationDate | date:'shortDate'}}
                 </span>
                 <span class="ont-pill" ng-if="facets.formats.active.length > 1">
-                  <b>Format</b> {{ontology.format}}
+                  <b>Format</b> {{::ontology.format}}
                 </span>
                 <span class="ont-pill" ng-if="ontology.type == 'ontology_view'">
-                  <b>View of</b> <a href="/ontologies/{{ontology.viewOfOnt.acronym}}">{{ontology.viewOfOnt.acronym}}</a>
+                  <b>View of</b> <a href="/ontologies/{{::ontology.viewOfOnt.acronym}}">{{::ontology.viewOfOnt.acronym}}</a>
                 </span>
                 <span class="ont-pill" ng-if="ontology.summaryOnly">Summary Only</span>
                 <span class="ont-pill" ng-if="facets.groups.active.length > 1">
@@ -225,25 +237,25 @@
                   <b>Admins</b> {{adminUsernames(ontology.administeredBy).join(', ')}}
                 </span>
                 <span class="ont-pill admin" ng-if="admin && ontology.pullLocation">
-                  <a href="{{ontology.pullLocation}}">Pull URL</a>
+                  <a href="{{::ontology.pullLocation}}">Pull URL</a>
                 </span>
                 <span class="ont-pill admin" ng-if="admin && ontology.submission">
-                  <b>Status</b> {{ontology.submissionStatusFormatted}}
+                  <b>Status</b> {{::ontology.submissionStatusFormatted}}
                 </span>
 
                 <%# Stat pills — same pill styling, count-forward, links to the section %>
                 <span class="ont-stats" ng-if="ontology.submission !== null && ontology.class_count > 0">
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
-                    <b>{{ontology.class_count_formatted}}</b> classes
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
+                    <b>{{::ontology.class_count_formatted}}</b> classes
                   </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
-                    <b>{{ontology.individual_count_formatted}}</b> {{ontology.format === 'SKOS' ? "concepts" : "instances"}}
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
+                    <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? "concepts" : "instances"}}
                   </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
-                    <b>{{ontology.projects.length}}</b> projects
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
+                    <b>{{::ontology.projects.length}}</b> projects
                   </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
-                    <b>{{ontology.notes.length}}</b> notes
+                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
+                    <b>{{::ontology.notes.length}}</b> notes
                   </a>
                 </span>
               </div>
@@ -251,6 +263,15 @@
 
             <span ng-hide="ontology.submission">No submissions available</span>
           </div>
+        </div>
+
+        <%# When more results match than are currently rendered, reveal the rest
+            as the user scrolls near the bottom of the list (see scroll handler in
+            app.js). A lightweight fallback button also grows the limit. %>
+        <div class="ontology-list-more" ng-if="filteredOntologies.length > render_limit">
+          <button type="button" class="ontology-list-more-btn" ng-click="growRenderLimit()">
+            Show more ({{filteredOntologies.length - render_limit}} more)
+          </button>
         </div>
         </div><%# /.ontology-list %>
       </div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -129,7 +129,7 @@
       <div id="ontologies" class="grid-80">
         <div class="browse-toolbar">
           <div id="searching">
-            <input type="text" placeholder="Search ontologies&hellip;" ng-model="searchText" ng-model-options="{debounce: 100}" class="search">
+            <input type="text" placeholder="Search ontologies&hellip;" ng-model="searchText" ng-model-options="{debounce: 300}" class="search">
           </div>
 
           <div id="sorting" ng-show="visible_ont_count">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -155,9 +155,24 @@
           </div>
         </div>
 
-        <%# Result count sits just above the list, not in the search/sort bar. %>
-        <div id="visible_ont_count" class="results-count" ng-show="visible_ont_count">
-          <b>{{visible_ont_count}}</b> of {{ontologies.length}} ontologies
+        <%# Count + active-filter chips row. Chips show each applied filter (and
+            the search term); each is removable, with a "Clear all" reset. %>
+        <div class="results-bar" ng-show="visible_ont_count || hasActiveFilters()">
+          <span id="visible_ont_count" class="results-count">
+            <b>{{visible_ont_count}}</b> of {{ontologies.length}} ontologies
+          </span>
+
+          <span class="filter-chips" ng-if="hasActiveFilters()">
+            <button type="button" class="filter-chip" ng-if="searchText" ng-click="clearSearch()">
+              <span class="filter-chip-label">Search: &ldquo;{{searchText}}&rdquo;</span>
+              <span class="filter-chip-x" aria-hidden="true">&times;</span>
+            </button>
+            <button type="button" class="filter-chip" ng-repeat="chip in activeFilterChips" ng-click="removeFilter(chip)">
+              <span class="filter-chip-label">{{chip.label}}</span>
+              <span class="filter-chip-x" aria-hidden="true">&times;</span>
+            </button>
+            <button type="button" class="filter-clear-all" ng-click="clearAllFilters()">Clear all</button>
+          </span>
         </div>
 
         <%# The ontology cards scroll independently below the (pinned) toolbar,
@@ -171,6 +186,7 @@
           </svg>
           <p class="browse-empty-title">No ontologies match your filters</p>
           <p class="browse-empty-text">Try a different search term or clear some filters.</p>
+          <button type="button" class="browse-empty-clear" ng-if="hasActiveFilters()" ng-click="clearAllFilters()">Clear all filters</button>
         </div>
 
         <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontologySortValue:(ontology_sort_order.charAt(0) === '-')" ng-if="ontology.show">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -210,6 +210,8 @@
                   %><span ng-bind-html="ontology.name | highlight:searchText"></span>
               </a>
               <span class="acronym-pill" ng-bind-html="ontology.acronym | highlight:searchText"></span>
+              <span class="status-pill status-retired" ng-if="ontology.status == 'retired'">Retired</span>
+              <span class="status-pill status-deprecated" ng-if="ontology.status == 'deprecated'">Deprecated</span>
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">
@@ -225,6 +227,7 @@
                 <span class="ont-pill">
                   <b>Uploaded</b> {{::ontology.creationDate | localeDate}}
                 </span>
+                <span class="ont-pill ont-pill-license" ng-if="ontology.hasLicense">License</span>
                 <span class="ont-pill" ng-if="facets.formats.active.length > 1">
                   <b>Format</b> {{::ontology.format}}
                 </span>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -163,10 +163,14 @@
         <%# The ontology cards scroll independently below the (pinned) toolbar,
             so the toolbar and the facet sidebar stay in place while browsing. %>
         <div class="ontology-list">
-        <div class="ontology" ng-show="visible_ont_count == 0" style="border: solid thin lightGray;">
-          <div style="text-align: center; color: gray; height: 2em; padding: 4em;">
-            <h2 style="font-weight: normal;">No matches!</h2>
-          </div>
+        <div class="browse-empty" ng-show="visible_ont_count == 0">
+          <svg class="browse-empty-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            <line x1="8" y1="11" x2="14" y2="11"></line>
+          </svg>
+          <p class="browse-empty-title">No ontologies match your filters</p>
+          <p class="browse-empty-text">Try a different search term or clear some filters.</p>
         </div>
 
         <div class="ontology grid-parent clearfix" ng-repeat="ontology in ontologies | orderBy:ontology_sort_order" ng-if="ontology.show">
@@ -175,8 +179,9 @@
             <h2 style="font-size: 1.5em;">
               <a href="/ontologies/{{ontology.acronym}}">
                 <span ng-if="debug">{{$index}} </span>
-                {{ontology.name}} ({{ontology.acronym}})
+                {{ontology.name}}
               </a>
+              <span class="acronym-pill">{{ontology.acronym}}</span>
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -218,7 +218,7 @@
               <%# Metadata + stats as one inline row of rounded pills %>
               <div class="ont-meta-pills">
                 <span class="ont-pill">
-                  <b>Uploaded</b> {{::ontology.creationDate | date:'d MMM y'}}
+                  <b>Uploaded</b> {{::ontology.creationDate | localeDate}}
                 </span>
                 <span class="ont-pill" ng-if="facets.formats.active.length > 1">
                   <b>Format</b> {{::ontology.format}}

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -213,7 +213,12 @@
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">
-              <p style="margin-bottom: 5px;" ng-bind-html="ontology.description | descriptionToText | highlight:searchText"></p>
+              <p class="ont-description" style="margin-bottom: 5px;"><%#
+                %><span ng-bind-html="ontology.description | descriptionSnippet:searchText:ontology._descExpanded | highlight:searchText"></span><%#
+                %> <a href="" class="ont-description-toggle" ng-if="descriptionHasMore(ontology)"
+                     ng-click="$event.preventDefault(); ontology._descExpanded = !ontology._descExpanded"><%#
+                  %>{{ontology._descExpanded ? 'Less' : 'More'}}</a><%#
+              %></p>
 
               <%# Metadata + stats as one inline row of rounded pills %>
               <div class="ont-meta-pills">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -206,10 +206,10 @@
             <div ng-if="ontology.type == 'ontology_view'" class="ontology_view_badge" title="This ontology is a view of {{::ontology.viewOfOnt.name}}">VIEW</div>
             <h2 style="font-size: 1.5em;">
               <a href="/ontologies/{{::ontology.acronym}}">
-                <span ng-if="debug">{{$index}} </span>
-                {{::ontology.name}}
+                <span ng-if="debug">{{$index}} </span><%#
+                  %><span ng-bind-html="ontology.name | highlight:searchText"></span>
               </a>
-              <span class="acronym-pill">{{::ontology.acronym}}</span>
+              <span class="acronym-pill" ng-bind-html="ontology.acronym | highlight:searchText"></span>
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -8,8 +8,8 @@
       <%=render partial: 'layouts/notices'%>
     </div>
     <div class="splash" ng-cloak>
-      <div style="font-size: 3em;">Ontologies loading</div>
-      <p>please wait...</p>
+      <div class="splash-spinner" aria-hidden="true"></div>
+      <p class="splash-text">Loading ontologies&hellip;</p>
     </div>
   </div>
 

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -213,7 +213,7 @@
               <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
             </h2>
             <div ng-if="ontology.submission">
-              <p style="margin-bottom: 5px;">{{::ontology.description | descriptionToText}}</p>
+              <p style="margin-bottom: 5px;" ng-bind-html="ontology.description | descriptionToText | highlight:searchText"></p>
 
               <%# Metadata + stats as one inline row of rounded pills %>
               <div class="ont-meta-pills">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -74,6 +74,16 @@
           </div>
         </div>
 
+        <div id="status_facet" class="facet">
+          <h4>Status</h4>
+          <div class="checkbox_list">
+            <span class="license-facet-row">
+              <input type="checkbox" id="show_retired" ng-model="facets.show_retired.active" ng-true-value="'yes'" ng-false-value="''">
+              <label for="show_retired">Show retired ontologies</label>
+            </span>
+          </div>
+        </div>
+
         <div id="category_facet" class="facet">
           <h4>Category</h4>
           <div class="checkbox_list">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -218,7 +218,7 @@
               <%# Metadata + stats as one inline row of rounded pills %>
               <div class="ont-meta-pills">
                 <span class="ont-pill">
-                  <b>Uploaded</b> {{::ontology.creationDate | date:'shortDate'}}
+                  <b>Uploaded</b> {{::ontology.creationDate | date:'d MMM y'}}
                 </span>
                 <span class="ont-pill" ng-if="facets.formats.active.length > 1">
                   <b>Format</b> {{::ontology.format}}

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -227,7 +227,9 @@
                 <span class="ont-pill">
                   <b>Uploaded</b> {{::ontology.creationDate | localeDate}}
                 </span>
-                <span class="ont-pill ont-pill-license" ng-if="ontology.hasLicense">License</span>
+                <a class="ont-pill ont-pill-license" ng-if="ontology.hasLicense"
+                   href="{{::ontology.license}}" target="_blank" rel="noopener"
+                   title="{{::ontology.license}}">{{::ontology.license | licenseLabel}}</a>
                 <span class="ont-pill" ng-if="facets.formats.active.length > 1">
                   <b>Format</b> {{::ontology.format}}
                 </span>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -64,6 +64,15 @@
           </div>
         </div>
 
+        <div id="license_facet" class="facet">
+          <div class="checkbox_list">
+            <span class="license-facet-row">
+              <input type="checkbox" id="has_license" ng-model="facets.has_license.active" ng-true-value="'yes'" ng-false-value="''">
+              <label for="has_license">Has a license</label>
+            </span>
+          </div>
+        </div>
+
         <div id="category_facet" class="facet">
           <h4>Category</h4>
           <div class="checkbox_list">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -246,7 +246,7 @@
               <span class="acronym-pill" ng-bind-html="ontology.acronym | highlight:searchText"></span>
               <span class="status-pill status-retired" ng-if="ontology.status == 'retired'">Retired</span>
               <span class="status-pill status-deprecated" ng-if="ontology.status == 'deprecated'">Deprecated</span>
-              <i title="Private Ontology" ng-if="ontology.private" class="icon-key locked_ont"></i>
+              <span class="status-pill status-private" ng-if="ontology.private" title="Private Ontology">Private</span>
             </h2>
             <div ng-if="ontology.submission">
               <p class="ont-description" style="margin-bottom: 5px;"><%#
@@ -288,10 +288,13 @@
                 <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
                   <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? "concepts" : "instances"}}
                 </a>
-                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
+                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=properties" ng-if="ontology.property_count > 0">
+                  <b>{{::ontology.property_count_formatted}}</b> properties
+                </a>
+                <a class="ont-pill ont-pill-stat ont-pill-muted" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
                   <b>{{::ontology.projects.length}}</b> projects
                 </a>
-                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
+                <a class="ont-pill ont-pill-stat ont-pill-muted" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
                   <b>{{::ontology.notes.length}}</b> notes
                 </a>
               </div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -84,6 +84,20 @@
           </div>
         </div>
 
+        <div id="visibility_facet" class="facet admin" ng-show="admin">
+          <h4>Visibility</h4>
+          <div class="checkbox_list">
+            <span class="license-facet-row">
+              <input type="checkbox" id="hide_private" ng-model="facets.hide_private.active" ng-true-value="'yes'" ng-false-value="''">
+              <label for="hide_private">Hide private ontologies</label>
+            </span>
+            <span class="license-facet-row">
+              <input type="checkbox" id="hide_public" ng-model="facets.hide_public.active" ng-true-value="'yes'" ng-false-value="''">
+              <label for="hide_public">Hide public ontologies</label>
+            </span>
+          </div>
+        </div>
+
         <div id="category_facet" class="facet">
           <h4>Category</h4>
           <div class="checkbox_list">

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -243,7 +243,7 @@
                   %>{{ontology._descExpanded ? 'Less' : 'More'}}</button><%#
               %></p>
 
-              <%# Metadata + stats as one inline row of rounded pills %>
+              <%# First line: upload date, license, and (facet-driven) metadata pills. %>
               <div class="ont-meta-pills">
                 <span class="ont-pill">
                   <b>Uploaded</b> {{::ontology.creationDate | localeDate}}
@@ -264,30 +264,35 @@
                 <span class="ont-pill" ng-if="facets.categories.active.length > 1">
                   <b>Categories</b> {{categoryNames(ontology.categories).join(', ')}}
                 </span>
-                <span class="ont-pill admin" ng-if="admin">
+              </div>
+
+              <%# Second line: ontology metrics — count-forward pills linking to the section. %>
+              <div class="ont-stat-pills" ng-if="ontology.submission !== null && ontology.class_count > 0">
+                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
+                  <b>{{::ontology.class_count_formatted}}</b> classes
+                </a>
+                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
+                  <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? "concepts" : "instances"}}
+                </a>
+                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
+                  <b>{{::ontology.projects.length}}</b> projects
+                </a>
+                <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
+                  <b>{{::ontology.notes.length}}</b> notes
+                </a>
+              </div>
+
+              <%# Admin-only pills on their own last row, so admin details don't
+                  intermix with the public metadata/stats above. %>
+              <div class="ont-admin-pills" ng-if="admin">
+                <span class="ont-pill admin">
                   <b>Admins</b> {{adminUsernames(ontology.administeredBy).join(', ')}}
                 </span>
-                <span class="ont-pill admin" ng-if="admin && ontology.pullLocation">
+                <span class="ont-pill admin" ng-if="ontology.pullLocation">
                   <a href="{{::ontology.pullLocation}}">Pull URL</a>
                 </span>
-                <span class="ont-pill admin" ng-if="admin && ontology.submission">
+                <span class="ont-pill admin" ng-if="ontology.submission">
                   <b>Status</b> {{::ontology.submissionStatusFormatted}}
-                </span>
-
-                <%# Stat pills — same pill styling, count-forward, links to the section %>
-                <span class="ont-stats" ng-if="ontology.submission !== null && ontology.class_count > 0">
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
-                    <b>{{::ontology.class_count_formatted}}</b> classes
-                  </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
-                    <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? "concepts" : "instances"}}
-                  </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
-                    <b>{{::ontology.projects.length}}</b> projects
-                  </a>
-                  <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
-                    <b>{{::ontology.notes.length}}</b> notes
-                  </a>
                 </span>
               </div>
             </div>

--- a/app/views/ontologies/browse.html.erb
+++ b/app/views/ontologies/browse.html.erb
@@ -283,19 +283,19 @@
               <%# Second line: ontology metrics — count-forward pills linking to the section. %>
               <div class="ont-stat-pills" ng-if="ontology.submission !== null && ontology.class_count > 0">
                 <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.format !== 'SKOS'">
-                  <b>{{::ontology.class_count_formatted}}</b> classes
+                  <b>{{::ontology.class_count_formatted}}</b> {{::ontology.class_count === 1 ? "class" : "classes"}}
                 </a>
                 <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=classes" ng-if="ontology.individual_count > 0">
-                  <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? "concepts" : "instances"}}
+                  <b>{{::ontology.individual_count_formatted}}</b> {{::ontology.format === 'SKOS' ? (ontology.individual_count === 1 ? "concept" : "concepts") : (ontology.individual_count === 1 ? "instance" : "instances")}}
                 </a>
                 <a class="ont-pill ont-pill-stat" href="/ontologies/{{::ontology.acronym}}?p=properties" ng-if="ontology.property_count > 0">
-                  <b>{{::ontology.property_count_formatted}}</b> properties
+                  <b>{{::ontology.property_count_formatted}}</b> {{::ontology.property_count === 1 ? "property" : "properties"}}
                 </a>
                 <a class="ont-pill ont-pill-stat ont-pill-muted" href="/ontologies/{{::ontology.acronym}}#projects_content" ng-if="ontology.projects.length > 0">
-                  <b>{{::ontology.projects.length}}</b> projects
+                  <b>{{::ontology.projects.length}}</b> {{::ontology.projects.length === 1 ? "project" : "projects"}}
                 </a>
                 <a class="ont-pill ont-pill-stat ont-pill-muted" href="/ontologies/{{::ontology.acronym}}?p=notes" ng-if="ontology.notes.length > 0">
-                  <b>{{::ontology.notes.length}}</b> notes
+                  <b>{{::ontology.notes.length}}</b> {{::ontology.notes.length === 1 ? "note" : "notes"}}
                 </a>
               </div>
 

--- a/public/browse/app.css
+++ b/public/browse/app.css
@@ -79,26 +79,6 @@
   float: right;
   margin-bottom: .5em;
 }
-@keyframes highlight {
-  0% {
-    background: yellow;
-  }
-  100% {
-    background: none;
-  }
-}
-@-webkit-keyframes highlight {
-  0% {
-    background: yellow;
-  }
-  100% {
-    background: none;
-  }
-}
-.trigger_highlight-add, .trigger_highlight-remove {
-  -webkit-animation: highlight 1s;
-  animation: highlight 1s;
-}
 #ontologies {
 }
 .clear {

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -705,4 +705,48 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     return formatter ? formatter.format(date) : date.toDateString();
   };
 })
+
+// Derive a short, human-readable license label from a license URL (the value
+// of a submission's hasLicense, e.g. "https://creativecommons.org/licenses/by/4.0/").
+// Recognises Creative Commons and OSI URLs; otherwise falls back to the host,
+// and finally to a plain "License" when the value isn't a URL we can parse.
+.filter('licenseLabel', function() {
+  var CC_NAMES = {
+    'by': 'CC BY', 'by-sa': 'CC BY-SA', 'by-nd': 'CC BY-ND',
+    'by-nc': 'CC BY-NC', 'by-nc-sa': 'CC BY-NC-SA', 'by-nc-nd': 'CC BY-NC-ND'
+  };
+  return function(url) {
+    if (!url) return 'License';
+    var s = String(url).trim();
+    var lower = s.toLowerCase();
+
+    // Creative Commons: /licenses/<code>/<version>/ or /publicdomain/zero|mark/<version>/
+    if (lower.indexOf('creativecommons.org') !== -1) {
+      var m = lower.match(/\/licenses\/([a-z-]+)\/([0-9.]+)/);
+      if (m) {
+        var name = CC_NAMES[m[1]] || ('CC ' + m[1].toUpperCase());
+        return name + ' ' + m[2];
+      }
+      if (lower.indexOf('/publicdomain/zero') !== -1) {
+        var z = lower.match(/\/zero\/([0-9.]+)/);
+        return 'CC0' + (z ? ' ' + z[1] : '');
+      }
+      if (lower.indexOf('/publicdomain/mark') !== -1) return 'Public Domain';
+      return 'Creative Commons';
+    }
+
+    // OSI-hosted licenses: the last path segment is the license id (e.g. MIT).
+    if (lower.indexOf('opensource.org') !== -1) {
+      var seg = s.replace(/\/+$/, '').split('/').pop();
+      if (seg) return seg.toUpperCase() === seg ? seg : seg;
+    }
+
+    // Otherwise, if it's a URL, show the host without a leading "www.".
+    var host = s.match(/^https?:\/\/([^/]+)/);
+    if (host) return host[1].replace(/^www\./, '');
+
+    // Not a URL — show the raw value if short, else a generic label.
+    return s.length <= 24 ? s : 'License';
+  };
+})
 ;

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -562,6 +562,34 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
   }
 })
 
+// Highlight occurrences of the current search query within a piece of text by
+// wrapping the matched substrings in <mark>. The input text is fully HTML-escaped
+// first and only our own <mark> tags are inserted, so the result is safe to bind
+// via ng-bind-html (trusted through $sce) without pulling in ngSanitize. When
+// there is no query the text is returned escaped and unmarked (a plain no-op).
+.filter('highlight', ['$sce', function($sce) {
+  var escapeHtml = function(s) {
+    return String(s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+  var escapeRegExp = function(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+  return function(text, query) {
+    var safe = escapeHtml(text == null ? '' : text);
+    var q = (query == null ? '' : String(query)).trim();
+    if (!q) return $sce.trustAsHtml(safe);
+    // Match the query case-insensitively; escape it so regex metacharacters in
+    // the search box are treated literally.
+    var re = new RegExp('(' + escapeRegExp(escapeHtml(q)) + ')', 'gi');
+    return $sce.trustAsHtml(safe.replace(re, '<mark class="search-hl">$1</mark>'));
+  };
+}])
+
 // Format a date using the visitor's browser locale (via Intl.DateTimeFormat)
 // rather than AngularJS's built-in `date` filter, which is frozen to en-US
 // unless an angular-i18n locale bundle is loaded (we load none). This shows a

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -175,6 +175,24 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     $scope.ontology_sort_order = newOrder;
   }
 
+  // Sort key for the ontology list. orderBy is given this function so we can
+  // normalise the "Name" sort: names can have stray leading whitespace and mixed
+  // case, which a plain field sort would order by raw char code (whitespace and
+  // capitals sorting before lowercase letters) — putting e.g. " Obesity..." and
+  // capitalised names out of place. For name we trim + lowercase; every other
+  // sort (popularity, counts, dates — all "[-]field") falls through to the raw
+  // field value so numeric/descending sorts are unchanged.
+  $scope.ontologySortValue = function(ontology) {
+    var order = $scope.ontology_sort_order || '';
+    var descending = order.charAt(0) === '-';
+    var field = descending ? order.substring(1) : order;
+
+    if (field === 'name') {
+      return (ontology.name || '').trim().toLowerCase();
+    }
+    return ontology[field];
+  }
+
   // This watches the facets and updates the list depending on which facets are selected
   // All facets are basically ANDed together and return true if no options under the facet are selected.
   $scope.$watch('facets', function() {

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -12,7 +12,7 @@ config( ['$locationProvider', function ($locationProvider) {
 
 var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ngAnimate', 'pasvaz.bindonce'])
 
-.controller('OntologyList', ['$scope', '$animate', '$timeout', '$filter', function($scope, $animate, $timeout, $filter) {
+.controller('OntologyList', ['$scope', '$timeout', '$filter', function($scope, $timeout, $filter) {
   // Default values
   $scope.visible_ont_count = 0;
 
@@ -30,7 +30,6 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 
   $scope.ontology_sort_order = initialSort;
   $scope.previous_sort_order = initialSort;
-  $scope.show_highlight = false;
 
   // Data transfer from Rails
   $scope.debug = jQuery(document).data().bp.development;
@@ -347,12 +346,10 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
   });
 
   var filterOntologies = function() {
-    var key, i, ontology, facet, facet_count, show, other_facets, count = 0;
+    var key, i, ontology, facet, facet_count, show, other_facets;
     // A changed search/facet set is a fresh result list — scroll the render
     // window back to the top so the user sees the best matches first.
     $scope.render_limit = RENDER_LIMIT_INITIAL;
-    $scope.show_highlight = false;
-    $scope.show_highlight = true;
 
     // Reset facet counts
     Object.keys($scope.facet_counts).forEach(function(key) {
@@ -402,14 +399,6 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 
     // Refresh the active-filter chips whenever the filters/search change.
     rebuildActiveFilterChips();
-
-    // Highlight the count
-    count = $("#visible_ont_count");
-    if (count.hasClass("trigger_highlight")) {
-      $animate.removeClass(count, "trigger_highlight");
-    } else {
-      $animate.addClass(count, "trigger_highlight");
-    }
   }
 
   var filterSearch = function() {

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -12,7 +12,7 @@ config( ['$locationProvider', function ($locationProvider) {
 
 var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ngAnimate', 'pasvaz.bindonce'])
 
-.controller('OntologyList', ['$scope', '$animate', '$timeout', function($scope, $animate, $timeout) {
+.controller('OntologyList', ['$scope', '$animate', '$timeout', '$filter', function($scope, $animate, $timeout, $filter) {
   // Default values
   $scope.visible_ont_count = 0;
 
@@ -49,6 +49,33 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     return 0;
   });
   $scope.groups_hash = jQuery(document).data().bp.groups_hash;
+
+  // Rendering window. The template only builds DOM for the first `render_limit`
+  // matching ontologies and grows the window as the user scrolls (or clicks
+  // "Show more"). This keeps each digest cheap regardless of catalog size —
+  // rendering the full ~1,500-item list was the cause of the typing stutter.
+  var RENDER_LIMIT_INITIAL = 40;
+  var RENDER_LIMIT_STEP = 40;
+  $scope.render_limit = RENDER_LIMIT_INITIAL;
+
+  // The concrete list ng-repeat renders (already filtered to matches and sorted).
+  // Built once per filter/sort change in rebuildFilteredList() rather than via
+  // filters in the ng-repeat expression, so the expensive filter+sort runs once
+  // per change instead of on every digest, and so ng-repeat has a stable array
+  // reference (no infinite digest).
+  $scope.filteredOntologies = [];
+
+  var rebuildFilteredList = function() {
+    var shown = $scope.ontologies.filter(function(o) { return o.show; });
+    var reverse = $scope.ontology_sort_order.charAt(0) === '-';
+    $scope.filteredOntologies =
+      $filter('orderBy')(shown, $scope.ontologySortValue, reverse);
+  };
+
+  // Reveal more matching rows (scroll handler and the "Show more" button).
+  $scope.growRenderLimit = function() {
+    $scope.render_limit += RENDER_LIMIT_STEP;
+  };
 
   // Search setup
   $scope.searchText = null;
@@ -294,13 +321,22 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 
   // Remember the chosen sort order for next time. Only persist the real options
   // (never the transient -search_rank the search flow switches to).
-  $scope.$watch('ontology_sort_order', function(newOrder) {
+  $scope.$watch('ontology_sort_order', function(newOrder, oldOrder) {
+    // Re-sort the rendered list when the order changes (the list is now a
+    // materialised array rather than an inline orderBy in the template).
+    if (newOrder !== oldOrder) {
+      $scope.render_limit = RENDER_LIMIT_INITIAL;
+      rebuildFilteredList();
+    }
     if (VALID_SORT_ORDERS.indexOf(newOrder) === -1) return;
     try { window.localStorage.setItem(SORT_STORAGE_KEY, newOrder); } catch (e) { /* storage unavailable */ }
   });
 
   var filterOntologies = function() {
     var key, i, ontology, facet, facet_count, show, other_facets, count = 0;
+    // A changed search/facet set is a fresh result list — scroll the render
+    // window back to the top so the user sees the best matches first.
+    $scope.render_limit = RENDER_LIMIT_INITIAL;
     $scope.show_highlight = false;
     $scope.show_highlight = true;
 
@@ -346,6 +382,9 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     }
 
     $scope.visible_ont_count = $scope.ontologies.filter(function(ont) {return ont.show}).length;
+
+    // Rebuild the concrete (filtered + sorted) list ng-repeat renders.
+    rebuildFilteredList();
 
     // Refresh the active-filter chips whenever the filters/search change.
     rebuildActiveFilterChips();
@@ -438,6 +477,26 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
         name: ont.name,
         description: ont.description
       })
+    });
+
+    // Infinite scroll: grow the render window as the user nears the bottom of
+    // the (independently scrolling) results list, so long result sets fill in
+    // without ever rendering the whole catalog at once.
+    $timeout(function() {
+      var list = document.querySelector('.ontology-list');
+      if (!list) return;
+      var ticking = false;
+      list.addEventListener('scroll', function() {
+        if (ticking) return;
+        ticking = true;
+        window.requestAnimationFrame(function() {
+          ticking = false;
+          var nearBottom = list.scrollTop + list.clientHeight >= list.scrollHeight - 400;
+          if (nearBottom && $scope.render_limit < $scope.filteredOntologies.length) {
+            $scope.$apply($scope.growRenderLimit);
+          }
+        });
+      });
     });
   }
   $timeout($scope.init);

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -168,6 +168,18 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
         return !!ontology.hasLicense;
       }
     },
+    // Retired ontologies are hidden by default (active "" hides them); the
+    // "Show retired" toggle sets active "yes" to include them. Same string-facet
+    // shape as has_license so it reuses the chip / remove / clear-all machinery.
+    show_retired: {
+      active: "",
+      ont_property: "status",
+      filter: function(ontology) {
+        if ($scope.facets.show_retired.active === "yes")
+          return true;
+        return ontology.status !== "retired";
+      }
+    },
     upload_date: {
       active: "",
       ont_property: "creationDate",
@@ -278,6 +290,7 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     }
     if (facetKey === 'types') return value === 'ontology_view' ? 'Ontology View' : 'Ontology';
     if (facetKey === 'has_license') return 'Has license';
+    if (facetKey === 'show_retired') return 'Including retired';
     return value;
   };
 

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -751,9 +751,10 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     }
 
     // OSI-hosted licenses: the last path segment is the license id (e.g. MIT).
+    // Uppercase it unless it already carries its own casing (e.g. "Apache-2.0").
     if (lower.indexOf('opensource.org') !== -1) {
       var seg = s.replace(/\/+$/, '').split('/').pop();
-      if (seg) return seg.toUpperCase() === seg ? seg : seg;
+      if (seg) return /^[a-z0-9.-]+$/.test(seg) ? seg.toUpperCase() : seg;
     }
 
     // Otherwise, if it's a URL, show the host without a leading "www.".

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -206,6 +206,82 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     return ontology[field];
   }
 
+  // --- Active-filter chips + clear-all -------------------------------------
+  // A removable chip is shown above the list for each active facet selection
+  // (and the search term), so users can see and undo what's applied without
+  // hunting the sidebar. "Ontology" under Entry Type is the default baseline and
+  // is intentionally not shown as a removable chip.
+
+  // Human-readable label for a facet value (categories/groups have names).
+  var facetValueLabel = function(facetKey, value) {
+    if (facetKey === 'categories') {
+      var cat = ($scope.categories || []).filter(function(c){ return c.id === value; })[0];
+      return cat ? cat.name : value;
+    }
+    if (facetKey === 'upload_date') {
+      var labels = { 1:'past day', 7:'past week', 30:'past month', 90:'past 3 months',
+                     180:'past 6 months', 365:'past year', 'all':'any time' };
+      return 'Uploaded: ' + (labels[value] || value);
+    }
+    if (facetKey === 'types') return value === 'ontology_view' ? 'Ontology View' : 'Ontology';
+    return value;
+  };
+
+  // Rebuild the chip list only when filters change (not on every digest) — a
+  // function returning a fresh array in an ng-repeat causes an infinite digest.
+  $scope.activeFilterChips = [];
+
+  var rebuildActiveFilterChips = function() {
+    var chips = [];
+    Object.keys($scope.facets).forEach(function(key) {
+      var active = $scope.facets[key].active;
+      if (angular.isArray(active)) {
+        active.forEach(function(v) {
+          // the default Entry Type = Ontology is the baseline, not a chip
+          if (key === 'types' && v === 'ontology') return;
+          chips.push({ facet: key, value: v, label: facetValueLabel(key, v) });
+        });
+      } else if (active !== '' && active != null) {
+        chips.push({ facet: key, value: active, label: facetValueLabel(key, active) });
+      }
+    });
+    $scope.activeFilterChips = chips;
+  };
+
+  $scope.removeFilter = function(chip) {
+    var active = $scope.facets[chip.facet].active;
+    if (angular.isArray(active)) {
+      var i = active.indexOf(chip.value);
+      if (i !== -1) active.splice(i, 1);
+    } else {
+      $scope.facets[chip.facet].active = '';
+    }
+  };
+
+  $scope.clearSearch = function() {
+    $scope.searchText = '';
+  };
+
+  // True when anything is applied beyond the defaults (so we can show a "Clear
+  // all" control and, in the empty state, nudge the user to reset). Returns a
+  // boolean (stable across digests, unlike an array).
+  $scope.hasActiveFilters = function() {
+    return $scope.activeFilterChips.length > 0 ||
+           !($scope.searchText === null || $scope.searchText === '');
+  };
+
+  $scope.clearAllFilters = function() {
+    Object.keys($scope.facets).forEach(function(key) {
+      var facet = $scope.facets[key];
+      if (angular.isArray(facet.active)) {
+        facet.active = (key === 'types') ? ['ontology'] : [];
+      } else {
+        facet.active = '';
+      }
+    });
+    $scope.searchText = '';
+  };
+
   // This watches the facets and updates the list depending on which facets are selected
   // All facets are basically ANDed together and return true if no options under the facet are selected.
   $scope.$watch('facets', function() {
@@ -270,6 +346,9 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     }
 
     $scope.visible_ont_count = $scope.ontologies.filter(function(ont) {return ont.show}).length;
+
+    // Refresh the active-filter chips whenever the filters/search change.
+    rebuildActiveFilterChips();
 
     // Highlight the count
     count = $("#visible_ont_count");

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -272,14 +272,26 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     $scope.ontologySortOrder("-search_rank");
     results = $scope.ontIndex.search($scope.searchText);
 
+    // An exact acronym match (case-insensitive) should always rank first — e.g.
+    // typing "GO" puts the GO ontology at the top, even if lunr's TF/IDF scoring
+    // would otherwise rank a name/description match higher. We add a large fixed
+    // boost so it beats any ordinary lunr score, and make sure the exact match
+    // is shown even if lunr didn't surface it.
+    var query = ($scope.searchText || "").trim().toLowerCase();
+    var EXACT_ACRONYM_BOOST = 1000;
+
     angular.forEach(results, function(r){found[r.ref] = r});
     for (i = 0; i < $scope.ontologies.length; i++) {
       ontology = $scope.ontologies[i];
       ontology.show = false;
       ontology.search_rank = 0;
-      if (found[ontology.id]) {
+      var exactAcronym = (ontology.acronym || "").toLowerCase() === query;
+      if (found[ontology.id] || exactAcronym) {
         ontology.show = true;
-        ontology.search_rank = found[ontology.id].score;
+        ontology.search_rank = (found[ontology.id] ? found[ontology.id].score : 0);
+        if (exactAcronym) {
+          ontology.search_rank += EXACT_ACRONYM_BOOST;
+        }
       }
     }
   }

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -81,6 +81,7 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
   $scope.ontIndex = lunr(function() {
     this.field('acronym', 100);
     this.field('name', 50);
+    this.field('keywords', 10);
     this.field('description');
     this.ref('id');
   });
@@ -491,6 +492,7 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
         id: ont.id,
         acronym: ont.acronym,
         name: ont.name,
+        keywords: ont.keywords,
         description: ont.description
       })
     });

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -15,8 +15,21 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 .controller('OntologyList', ['$scope', '$animate', '$timeout', function($scope, $animate, $timeout) {
   // Default values
   $scope.visible_ont_count = 0;
-  $scope.ontology_sort_order = "-popularity";
-  $scope.previous_sort_order = "-popularity";
+
+  // Persist the chosen sort order across page views/sessions via localStorage.
+  // -search_rank is transient (only while a search is active) so it is never
+  // persisted; a stored value is only honoured if it's one of the real options.
+  var SORT_STORAGE_KEY = 'bp.ontologies.sort_order';
+  var VALID_SORT_ORDERS = [
+    '-popularity', 'name', '-class_count', '-individual_count',
+    '-project_count', '-note_count', '-creationDate'
+  ];
+  var storedSort = null;
+  try { storedSort = window.localStorage.getItem(SORT_STORAGE_KEY); } catch (e) { /* storage unavailable */ }
+  var initialSort = (VALID_SORT_ORDERS.indexOf(storedSort) !== -1) ? storedSort : "-popularity";
+
+  $scope.ontology_sort_order = initialSort;
+  $scope.previous_sort_order = initialSort;
   $scope.show_highlight = false;
 
   // Data transfer from Rails
@@ -201,6 +214,13 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 
   $scope.$watch('searchText', function() {
     filterOntologies();
+  });
+
+  // Remember the chosen sort order for next time. Only persist the real options
+  // (never the transient -search_rank the search flow switches to).
+  $scope.$watch('ontology_sort_order', function(newOrder) {
+    if (VALID_SORT_ORDERS.indexOf(newOrder) === -1) return;
+    try { window.localStorage.setItem(SORT_STORAGE_KEY, newOrder); } catch (e) { /* storage unavailable */ }
   });
 
   var filterOntologies = function() {

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -482,23 +482,58 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
       })
     });
 
-    // Infinite scroll: grow the render window as the user nears the bottom of
-    // the (independently scrolling) results list, so long result sets fill in
-    // without ever rendering the whole catalog at once.
     $timeout(function() {
+      // Infinite scroll: grow the render window as the user nears the bottom of
+      // the (independently scrolling) results list, so long result sets fill in
+      // without ever rendering the whole catalog at once.
       var list = document.querySelector('.ontology-list');
-      if (!list) return;
-      var ticking = false;
-      list.addEventListener('scroll', function() {
-        if (ticking) return;
-        ticking = true;
-        window.requestAnimationFrame(function() {
-          ticking = false;
-          var nearBottom = list.scrollTop + list.clientHeight >= list.scrollHeight - 400;
-          if (nearBottom && $scope.render_limit < $scope.filteredOntologies.length) {
-            $scope.$apply($scope.growRenderLimit);
-          }
+      if (list) {
+        var ticking = false;
+        list.addEventListener('scroll', function() {
+          if (ticking) return;
+          ticking = true;
+          window.requestAnimationFrame(function() {
+            ticking = false;
+            var nearBottom = list.scrollTop + list.clientHeight >= list.scrollHeight - 400;
+            if (nearBottom && $scope.render_limit < $scope.filteredOntologies.length) {
+              $scope.$apply($scope.growRenderLimit);
+            }
+          });
         });
+      }
+
+      // Keyboard affordances for the search box:
+      //   - focus it on load,
+      //   - "/" from anywhere jumps to it (unless already typing in a field),
+      //   - Esc clears and blurs it.
+      var searchBox = document.getElementById('ontology_search');
+      if (!searchBox) return;
+
+      searchBox.focus();
+
+      var isTypingTarget = function(el) {
+        if (!el) return false;
+        var tag = (el.tagName || '').toLowerCase();
+        return tag === 'input' || tag === 'textarea' || tag === 'select' ||
+               el.isContentEditable;
+      };
+
+      document.addEventListener('keydown', function(e) {
+        // "/" focuses search — but not while the user is typing elsewhere, and
+        // not when a modifier is held (so browser/OS shortcuts still work).
+        if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey &&
+            !isTypingTarget(e.target)) {
+          e.preventDefault();
+          searchBox.focus();
+          return;
+        }
+        // Esc clears + blurs the search when it's focused.
+        if (e.key === 'Escape' && document.activeElement === searchBox) {
+          if ($scope.searchText) {
+            $scope.$apply(function() { $scope.searchText = ''; });
+          }
+          searchBox.blur();
+        }
       });
     });
   }

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -561,4 +561,26 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     return text.split(/\.\W/)[0];
   }
 })
+
+// Format a date using the visitor's browser locale (via Intl.DateTimeFormat)
+// rather than AngularJS's built-in `date` filter, which is frozen to en-US
+// unless an angular-i18n locale bundle is loaded (we load none). This shows a
+// day/short-month/year date localised to the user — e.g. "21 Mar 2026" (en),
+// "21 mars 2026" (fr), "2026年3月21日" (ja). Falls back to the raw value if the
+// input can't be parsed or Intl is unavailable.
+.filter('localeDate', function() {
+  var formatter = null;
+  if (typeof Intl !== 'undefined' && Intl.DateTimeFormat) {
+    // `undefined` locale => use the browser's default locale.
+    formatter = new Intl.DateTimeFormat(undefined, {
+      day: 'numeric', month: 'short', year: 'numeric'
+    });
+  }
+  return function(value) {
+    if (!value) return value;
+    var date = (value instanceof Date) ? value : new Date(value);
+    if (isNaN(date.getTime())) return value;
+    return formatter ? formatter.format(date) : date.toDateString();
+  };
+})
 ;

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -155,6 +155,18 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
         return true;
       }
     },
+    // "Has license" toggle. Modelled as a string facet (active is "" when off,
+    // "yes" when on) rather than a boolean, so it reuses the existing chip /
+    // remove / clear-all machinery unchanged.
+    has_license: {
+      active: "",
+      ont_property: "hasLicense",
+      filter: function(ontology) {
+        if ($scope.facets.has_license.active !== "yes")
+          return true;
+        return !!ontology.hasLicense;
+      }
+    },
     upload_date: {
       active: "",
       ont_property: "creationDate",
@@ -264,6 +276,7 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
       return 'Uploaded: ' + (labels[value] || value);
     }
     if (facetKey === 'types') return value === 'ontology_view' ? 'Ontology View' : 'Ontology';
+    if (facetKey === 'has_license') return 'Has license';
     return value;
   };
 

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -233,6 +233,20 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     return ontology[field];
   }
 
+  // Whether an ontology's description is long enough that the collapsed card
+  // view truncates it — i.e. whether the "More" toggle should be shown. Kept in
+  // sync with descriptionSnippet's SNIPPET_LEN. The stripped length is cached on
+  // the ontology so this is cheap to call from the template each digest.
+  var DESC_SNIPPET_LEN = 260;
+  $scope.descriptionHasMore = function(ontology) {
+    if (!ontology) return false;
+    if (ontology._descTextLen == null) {
+      ontology._descTextLen = String(ontology.description || '')
+        .replace(/<[^>]+>/gm, ' ').replace(/\s+/g, ' ').trim().length;
+    }
+    return ontology._descTextLen > DESC_SNIPPET_LEN;
+  };
+
   // --- Active-filter chips + clear-all -------------------------------------
   // A removable chip is shown above the list for each active facet selection
   // (and the search term), so users can see and undo what's applied without
@@ -560,6 +574,62 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     text = String(text).replace(/<[^>]+>/gm, '');
     return text.split(/\.\W/)[0];
   }
+})
+
+// Produce the description text shown on a result card. Strips HTML, then:
+//   - expanded === true  -> the full description (used by the "More" toggle).
+//   - a search query that appears AFTER the leading excerpt -> a snippet
+//     centred on the first match (Google-style, with leading/trailing "…") so
+//     the description explains why the result matched.
+//   - otherwise -> a leading excerpt (SNIPPET_LEN chars, cut on a word
+//     boundary) with a trailing "…" when the text was truncated.
+// The result is plain text; it is highlighted separately by the `highlight`
+// filter downstream in the template.
+.filter('descriptionSnippet', function() {
+  var SNIPPET_LEN = 260;   // leading excerpt length
+  var CONTEXT_BEFORE = 60; // chars of context kept before a mid-text match
+
+  var stripAndCollapse = function(text) {
+    return String(text == null ? '' : text)
+      .replace(/<[^>]+>/gm, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  };
+
+  // Truncate at or before `len`, preferring the last word boundary, and append
+  // an ellipsis. `prefix` is prepended (used for the leading "…" of a snippet).
+  var clip = function(text, len, prefix) {
+    prefix = prefix || '';
+    if (text.length <= len) return prefix + text;
+    var cut = text.slice(0, len);
+    var lastSpace = cut.lastIndexOf(' ');
+    if (lastSpace > len * 0.6) cut = cut.slice(0, lastSpace);
+    return prefix + cut.replace(/[\s.,;:]+$/, '') + '…';
+  };
+
+  return function(description, query, expanded) {
+    var text = stripAndCollapse(description);
+    if (expanded) return text;
+
+    var q = (query == null ? '' : String(query)).trim().toLowerCase();
+    var matchAt = q ? text.toLowerCase().indexOf(q) : -1;
+
+    // No query, no match, or the match already falls inside the leading
+    // excerpt: just show the leading excerpt.
+    if (matchAt === -1 || matchAt < SNIPPET_LEN - 20) {
+      return clip(text, SNIPPET_LEN, '');
+    }
+
+    // Match is past the leading excerpt: window around it.
+    var start = Math.max(0, matchAt - CONTEXT_BEFORE);
+    // Back up to a word boundary so we don't start mid-word.
+    if (start > 0) {
+      var sp = text.indexOf(' ', start);
+      if (sp !== -1 && sp < matchAt) start = sp + 1;
+    }
+    var windowText = text.slice(start);
+    return clip(windowText, SNIPPET_LEN, start > 0 ? '…' : '');
+  };
 })
 
 // Highlight occurrences of the current search query within a piece of text by

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -76,6 +76,17 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     $scope.render_limit += RENDER_LIMIT_STEP;
   };
 
+  // Reset the render window for a fresh result list: shrink back to the initial
+  // row count and scroll the list container to the top. Without the scroll
+  // reset, a stale scroll position from the previous (longer) list leaves the
+  // user at the bottom of the new results and can immediately re-trigger the
+  // near-bottom growth.
+  var resetRenderWindow = function() {
+    $scope.render_limit = RENDER_LIMIT_INITIAL;
+    var list = document.querySelector('.ontology-list');
+    if (list) list.scrollTop = 0;
+  };
+
   // Search setup
   $scope.searchText = null;
   $scope.ontIndex = lunr(function() {
@@ -393,7 +404,7 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     // Re-sort the rendered list when the order changes (the list is now a
     // materialised array rather than an inline orderBy in the template).
     if (newOrder !== oldOrder) {
-      $scope.render_limit = RENDER_LIMIT_INITIAL;
+      resetRenderWindow();
       rebuildFilteredList();
     }
     if (VALID_SORT_ORDERS.indexOf(newOrder) === -1) return;
@@ -402,9 +413,9 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
 
   var filterOntologies = function() {
     var key, i, ontology, facet, facet_count, show, other_facets;
-    // A changed search/facet set is a fresh result list — scroll the render
-    // window back to the top so the user sees the best matches first.
-    $scope.render_limit = RENDER_LIMIT_INITIAL;
+    // A changed search/facet set is a fresh result list — reset the render
+    // window and scroll back to the top so the user sees the best matches first.
+    resetRenderWindow();
 
     // Reset facet counts
     Object.keys($scope.facet_counts).forEach(function(key) {

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -305,6 +305,10 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
       var cat = ($scope.categories || []).filter(function(c){ return c.id === value; })[0];
       return cat ? cat.name : value;
     }
+    if (facetKey === 'groups') {
+      var grp = ($scope.groups || []).filter(function(g){ return g.id === value; })[0];
+      return grp ? grp.name : value;
+    }
     if (facetKey === 'upload_date') {
       var labels = { 1:'past day', 7:'past week', 30:'past month', 90:'past 3 months',
                      180:'past 6 months', 365:'past year', 'all':'any time' };

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -180,6 +180,28 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
         return ontology.status !== "retired";
       }
     },
+    // Admin-only: hide private ontologies from the list. Off by default (active
+    // "" shows everything); "yes" excludes private ontologies. Same string-facet
+    // shape so it reuses the chip / remove / clear-all machinery.
+    hide_private: {
+      active: "",
+      ont_property: "private",
+      filter: function(ontology) {
+        if ($scope.facets.hide_private.active !== "yes")
+          return true;
+        return !ontology.private;
+      }
+    },
+    // Admin-only mirror of hide_private: hide public (non-private) ontologies.
+    hide_public: {
+      active: "",
+      ont_property: "private",
+      filter: function(ontology) {
+        if ($scope.facets.hide_public.active !== "yes")
+          return true;
+        return !!ontology.private;
+      }
+    },
     upload_date: {
       active: "",
       ont_property: "creationDate",
@@ -291,6 +313,8 @@ var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ng
     if (facetKey === 'types') return value === 'ontology_view' ? 'Ontology View' : 'Ontology';
     if (facetKey === 'has_license') return 'Has license';
     if (facetKey === 'show_retired') return 'Including retired';
+    if (facetKey === 'hide_private') return 'Hiding private';
+    if (facetKey === 'hide_public') return 'Hiding public';
     return value;
   };
 

--- a/public/browse/app.js
+++ b/public/browse/app.js
@@ -10,7 +10,7 @@ config( ['$locationProvider', function ($locationProvider) {
 }])
 ;
 
-var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'ngAnimate', 'pasvaz.bindonce'])
+var app = angular.module('FacetedBrowsing.OntologyList', ['checklist-model', 'pasvaz.bindonce'])
 
 .controller('OntologyList', ['$scope', '$timeout', '$filter', function($scope, $timeout, $filter) {
   // Default values


### PR DESCRIPTION
# Modernize the ontologies browse page

Updates the styling and interaction of the `/ontologies` browse page. This is a
front-end change only — the SCSS, the browse template, and the AngularJS
controller in `public/browse/app.js`. No change to the data model or the
structure of the Angular app.

## Before / after

Before (current production page):

![Old ontologies browse page](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/d6816f433c650e47923455b26e9b36895dcf9af8/browse-before.png)

After:

![New ontologies browse page](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/d6816f433c650e47923455b26e9b36895dcf9af8/browse-after.png)

## Changes

**Layout:**
- Removed the "Browse" title, which duplicated the nav label and pushed content
  down.
- Moved the search box into a toolbar at the top of the results column, so the
  primary action is the first thing on the page.
- Stats (classes, projects, notes, instances) are inline pills instead of boxed
  badges floated to the right, so each card reads as one block instead of two
  columns.
- Acronym shown as a pill next to the ontology name, so it is easy to spot
  without reading it out of the title.
- The search bar and facet sidebar stay in place; only the results column
  scrolls. This keeps the controls reachable while scrolling a long list.

**Search:**
- The matched term is highlighted in the name, acronym, and description, so it
  is visible why a result matched.
- When the match falls outside the leading part of the description, the shown
  text is a snippet centered on the match, so a match in a long description is
  not hidden by truncation.
- Active facets and the search term appear as removable chips, with a "Clear
  all" that resets them. This makes the current filter state visible and
  reversible without hunting through the sidebar.
- Search also matches an ontology's self-declared keywords (folded into the
  index), so a query like "rare diseases" surfaces an ontology tagged with it
  even when the words aren't in its name or description. Keywords aren't
  displayed; this only improves recall for the ontologies that declare them.

**Performance:**
- The list previously rendered all ~1,500 ontologies and hid the non-matching
  ones with `ng-if`, so every keystroke reconciled ~1,300 DOM cards and ~34,000
  watchers. It now renders only the matching rows, capped to a window that grows
  on scroll. Measured search cost per keystroke went from ~110–270 ms to ~30 ms,
  and watchers from ~34,000 to ~1,300 — this removes the visible typing lag.
- The search input is debounced (300 ms) so filtering runs when typing pauses
  rather than on every keystroke, avoiding repeated full-list passes mid-word.

**Other:**
- Upload dates use the browser locale via `Intl.DateTimeFormat` (e.g.
  "4 Mar 2026") instead of `date:'shortDate'`, whose numeric form is ambiguous
  between day/month order (e.g. "3/4/26" could be 4 March or 3 April).
- Descriptions show more text, with an inline More/Less toggle, so a short
  summary is visible without opening the ontology but the full text is one click
  away.
- Sort order is stored in `localStorage` and restored on the next visit, so a
  chosen sort does not reset each time.
- An exact acronym match (e.g. "GO") is ranked first, so searching for a known
  acronym returns that ontology at the top.
- "Name" sort trims and lowercases, so it is case-insensitive and no longer
  places whitespace/capitalized names out of order.
- Search box is focused on load; "/" focuses it from elsewhere; Esc clears it —
  the common case (type to search) needs no click.
- Reworked the loading splash and the empty state.
- Removed the fade animation that fired on the result count on every filter; the
  chips and result count already show that a filter was applied, so it was
  redundant.

**Card pills:**
- License pill (green-tinted) on ontologies whose latest submission declares a
  license. It names the license — e.g. "CC BY 4.0", "CC0 1.0", "MIT" (derived
  from the license URL) — and links to it, so the reuse terms are visible while
  scanning. Shown only when a license is present.
- Retired (red) / Deprecated (amber) pill beside the acronym when the latest
  submission has that lifecycle status, so a superseded ontology is obvious at a
  glance. The browse controller now includes `status` and `hasLicense` in the
  submissions fetch.
- A "Has a license" toggle in the sidebar limits results to ontologies that
  declare a license, for when you need one you can reuse. It ANDs with search
  and the other facets, shows as a removable chip, and is reset by "Clear all".
- Retired ontologies are now hidden by default (they are rarely what someone
  browsing wants). A "Show retired ontologies" toggle under a new Status facet
  brings them back; turning it on shows an "Including retired" chip. Deprecated
  ontologies are still shown, flagged with the amber pill.

![Search results with highlighting and chips](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/d6816f433c650e47923455b26e9b36895dcf9af8/browse-search.png)

Searching "GO": the exact acronym match (Gene Ontology) ranks first, with the
search chip, Clear all, and the term highlighted in names, acronyms, and
descriptions.

![Empty state when no ontologies match](https://raw.githubusercontent.com/matthewhorridge/bioportal_web_ui/d6816f433c650e47923455b26e9b36895dcf9af8/browse-empty.png)

Empty state when nothing matches, with a "Clear all filters" action.

## Not included

- Search/sort/filters are not reflected in the URL, so results are not yet
  shareable or bookmarkable.
- The full catalog (~1.9 MB of JSON) is still inlined into the page on load.
  Reducing this is a backend change and is out of scope here.

## Testing

Checked locally against the full catalog (~1,500 ontologies): search, facets,
sorting, chips, highlighting, More/Less, infinite scroll, and the keyboard
shortcuts. Search interaction measured at ~30 ms per keystroke.
