### PR TITLE
Restore esbuild JS bundle in the Angular layout

### DIFF
--- a/app/views/layouts/angular.html.erb
+++ b/app/views/layouts/angular.html.erb
@@ -32,6 +32,7 @@
   <%= stylesheet_link_tag "application" %>
 </head>
 <body class="<%= controller_name %> <%= action_name %> d-flex flex-column h-100">
+  <%= javascript_include_tag "application_esbuild", "data-turbo-track": "reload", type: "module" %>
   <%=javascript_include_tag "vendor"%>
   <%=javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.min.js"%>
   <%=javascript_include_tag "//cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.1/Chart.min.js"%>


### PR DESCRIPTION
Fixes #529

## Problem

On `/ontologies` (Browse), clicking the account dropdown for an authenticated user navigated to a non-existent `/browse` page (404) instead of opening the menu.

## Cause

The Browse page renders through the legacy Angular layout. Commit ec94ae78 removed the esbuild bundle include from that layout, and the replacement `application` include only landed in the appliance-mode branch. In non-appliance deployments the page loaded no Bootstrap JS, so `data-bs-toggle="dropdown"` clicks fell through to their `href="#"` — which the layout's `<base href="/browse/">` tag resolves to `/browse/#`, causing a real navigation and a 404.

## Fix

Restore the `application_esbuild` include in `angular.html.erb`, matching how `_header.html.erb` loads it on every other page (the bundle was renamed from `application-esbuild` since the original removal). This also revives everything else on the page that depends on that bundle:

- Support dropdown (broken for anonymous users too)
- Mobile navbar toggler (`data-bs-toggle="collapse"`)
- Stimulus `popup` controller (browse-help and Submit-feedback links)
- Cookie-consent Turbo frame

Turbo doesn't interfere with the Angular app: the bundle sets `Turbo.session.drive = false`, and this same include coexisted with the Angular page before its removal in October 2024.

## Testing

Verified locally in the dev container: account and Support dropdowns open correctly on `/ontologies`, and the Angular ontology list still loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
