### PR TITLE
Improve class-tree expand feedback and animation

### DIFF
--- a/app/assets/stylesheets/tree.scss
+++ b/app/assets/stylesheets/tree.scss
@@ -1,9 +1,75 @@
 /********************
 ## TREE VIEW
 *********************/
-/* Expand/collapse chevron: one chevron-right SVG, rotated when open */
+/* Expand/collapse chevron: one chevron-right SVG, rotated when open. The
+   transition smooths both the open/close toggle and the optimistic flip below. */
+.tree-chevron {
+  transition: transform 0.15s ease;
+}
 .tree-chevron.open {
   transform: rotate(90deg);
+}
+
+/* Optimistic expand feedback. Expanding a collapsed node is a Turbo Frame
+   round-trip that can take a second or more; the chevron only flips once the
+   server response swaps it for the "open" icon. To give immediate feedback on
+   the clicked node, the simple-tree controller adds `.tree-expanding` to the
+   <li> on click and removes it when the children frame loads. While present we
+   rotate the chevron straight away and pulse it to signal "loading". (The
+   clickable chevron sits in a plain <turbo_frame> custom element that Turbo
+   never marks [busy], so this can't be keyed off [busy] in CSS — hence the
+   controller-set class.) */
+li.tree-expanding > turbo_frame[id$="_open_link"] .tree-chevron,
+li.tree-expanding > turbo-frame[id$="_open_link"] .tree-chevron {
+  transform: rotate(90deg);
+  animation: tree-chevron-pulse 0.7s ease-in-out infinite;
+}
+@keyframes tree-chevron-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+/* The per-node "loading children" indicator (Turbo's show-if-loading block) was
+   a centre-aligned, padded box that opened a large gap and shoved sibling nodes
+   down while children loaded. Render it as a compact, indent-aligned inline cue
+   under the node label instead, so nothing jumps. */
+.simpleTree .show-if-loading.my-auto { margin: 0 !important; }
+.simpleTree .show-if-loading > .p-3 {
+  padding: 0 0 0 1.7rem !important;
+  min-height: 18px;
+  display: flex;
+  align-items: center;
+}
+.simpleTree .show-if-loading .loader-component {
+  justify-content: flex-start !important;
+  display: flex;
+}
+.simpleTree .show-if-loading .lds-ellipsis {
+  transform: scale(0.42);
+  transform-origin: left center;
+  margin: 0;
+  height: 12px;
+  width: 40px;
+}
+
+/* Slide the arriving children in, so an expanded subtree feels continuous
+   rather than popping into place. */
+.simpleTree turbo-frame[id$="_childs"] > ul {
+  animation: tree-slide-in 0.18s ease-out;
+}
+@keyframes tree-slide-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tree-chevron,
+  li.tree-expanding > turbo_frame[id$="_open_link"] .tree-chevron,
+  li.tree-expanding > turbo-frame[id$="_open_link"] .tree-chevron,
+  .simpleTree turbo-frame[id$="_childs"] > ul {
+    transition: none;
+    animation: none;
+  }
 }
 
 // The tree scrolls inside #sd_content (see the Classes-pane rules in

--- a/app/assets/stylesheets/tree.scss
+++ b/app/assets/stylesheets/tree.scss
@@ -53,8 +53,12 @@ li.tree-expanding > turbo-frame[id$="_open_link"] .tree-chevron {
 }
 
 /* Slide the arriving children in, so an expanded subtree feels continuous
-   rather than popping into place. */
-.simpleTree turbo-frame[id$="_childs"] > ul {
+   rather than popping into place. Matched on the children <ul> rather than the
+   wrapping frame's id: the `<turbo-frame id="…_childs">` in the page is only an
+   empty placeholder, and ConceptsController#index replaces it outright with the
+   sub-tree render, whose frame carries no id at all (TreeViewComponent is given
+   no `id:` on that path). Keying off `[id$="_childs"]` therefore never matched. */
+.simpleTree turbo-frame > ul.tree-border-left {
   animation: tree-slide-in 0.18s ease-out;
 }
 @keyframes tree-slide-in {
@@ -66,7 +70,7 @@ li.tree-expanding > turbo-frame[id$="_open_link"] .tree-chevron {
   .tree-chevron,
   li.tree-expanding > turbo_frame[id$="_open_link"] .tree-chevron,
   li.tree-expanding > turbo-frame[id$="_open_link"] .tree-chevron,
-  .simpleTree turbo-frame[id$="_childs"] > ul {
+  .simpleTree turbo-frame > ul.tree-border-left {
     transition: none;
     animation: none;
   }

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -11,6 +11,65 @@ export default class extends Controller {
 
   connect () {
     this.#centerTreeView()
+    this.#bindExpandFeedback()
+  }
+
+  disconnect () {
+    if (this.boundExpandClick) {
+      this.element.removeEventListener('click', this.boundExpandClick, true)
+    }
+    this.expandObserver?.disconnect()
+  }
+
+  // Give immediate feedback when a collapsed node is expanded. Expanding is a
+  // server round-trip that can take a second or more, and the chevron only
+  // flips once the response arrives. On click of a chevron's expand link we
+  // optimistically mark the <li> `.tree-expanding` (CSS rotates + pulses the
+  // chevron and shows a compact inline loader), and clear it once that node's
+  // children actually land in the DOM.
+  //
+  // The children arrive via a Turbo Stream (see ConceptsController#index), which
+  // does NOT emit turbo:frame-load on the target frame — so we can't key the
+  // "done" signal off a frame event. Instead a MutationObserver watches for the
+  // children list being inserted under any expanding node, which is robust to
+  // however the markup gets there. Re-collapse/expand of already-loaded subtrees
+  // uses the instant #toggleChildren path and never gets the class.
+  #bindExpandFeedback () {
+    this.boundExpandClick = (event) => {
+      const link = event.target.closest('[id$="_open_link"] a')
+      if (!link) return
+      const li = link.closest('li')
+      if (!li) return
+      li.classList.add('tree-expanding')
+      // Safety net: if children never arrive (leaf-like node, request error, or a
+      // click that doesn't trigger a load), clear the state after a few seconds so
+      // the chevron can't pulse forever. Success clears it sooner via the observer.
+      clearTimeout(this.expandTimers?.get(li))
+      const timer = setTimeout(() => li.classList.remove('tree-expanding'), 8000)
+      ;(this.expandTimers ??= new WeakMap()).set(li, timer)
+    }
+    this.element.addEventListener('click', this.boundExpandClick, true)
+
+    // Children arrive via a Turbo Stream (ConceptsController#index), which does
+    // not emit turbo:frame-load on the target frame — so watch the DOM for the
+    // children being inserted instead. Robust to however the markup lands.
+    this.expandObserver = new MutationObserver(() => {
+      this.element.querySelectorAll('li.tree-expanding').forEach((li) => {
+        // Children have arrived once a nested children list exists under this node.
+        // Match on the children <ul> (id-independent) rather than a specific frame
+        // id, since Turbo swaps the frame markup on expand.
+        if (li.querySelector('ul.tree-border-left, [id$="_childs"] ul, [id$="_childs"] li')) {
+          this.#stopExpanding(li)
+        }
+      })
+    })
+    this.expandObserver.observe(this.element, { childList: true, subtree: true })
+  }
+
+  #stopExpanding (li) {
+    li.classList.remove('tree-expanding')
+    const timer = this.expandTimers?.get(li)
+    if (timer) { clearTimeout(timer); this.expandTimers.delete(li) }
   }
 
   select (event) {


### PR DESCRIPTION
# Improve class-tree expand feedback and animation

Expanding a node in the Classes-tab hierarchy is a server round-trip that can
take a second or more. During that time the UI gave no feedback on the clicked
node (the chevron only flipped once the response arrived), and the loading
placeholder was a centred, padded block that opened a large gap and pushed the
sibling nodes down. This makes expansion feel clunky and unresponsive.

This is a front-end change only — the underlying fetch latency is unchanged.

## Changes

**Optimistic expand feedback.**
- On clicking a collapsed node's chevron, the `simple-tree` controller adds
  `.tree-expanding` to the `<li>`, which rotates and pulses the chevron
  immediately instead of only flipping once the response lands, and shows a
  compact loading cue.
- The class is cleared when the children list is actually inserted, watched via
  a `MutationObserver` — children arrive by Turbo Stream, which emits no
  `turbo:frame-load` on the target frame, so a frame-event hook wouldn't fire.
- An 8s timeout backstop guarantees the class can never persist (and the chevron
  can't pulse forever) if children never arrive — e.g. a leaf-like node, a
  request error, or a click that triggers no load.

**Compact loading indicator.**
- The per-node loading block was `my-auto mx-auto p-3` — centred and padded — so
  it opened a large gap and shoved siblings down while loading. It now renders as
  a small, indent-aligned inline cue under the node label, so nothing jumps.

**Slide-in animation.**
- Arriving children slide in briefly so an expanded subtree feels continuous
  rather than popping into place. A `prefers-reduced-motion` query disables the
  transitions and animations.

## Not included

- The ~1–3s per-node fetch latency itself is a backend concern (child-fetch
  speed / caching) and is out of scope here; these changes make the wait *feel*
  responsive rather than making it shorter.

## Files

- `app/javascript/controllers/simple_tree_controller.js` — optimistic feedback +
  observer-based clearing + timeout backstop.
- `app/assets/stylesheets/tree.scss` — chevron transition/flip, compact loader,
  slide-in, reduced-motion guard.

## Testing

Verified on the BCIO Classes tree against a live backend: clicking a chevron
immediately rotates/pulses it and shows the compact loader; the state clears the
moment children are inserted; re-collapsing/expanding an already-loaded subtree
is unaffected (instant toggle path).
