### PR TITLE
Show the class Short Id on the concept Details pane

### DIFF
--- a/app/assets/stylesheets/concepts.scss
+++ b/app/assets/stylesheets/concepts.scss
@@ -206,3 +206,44 @@ div.synonym-change-request button {
     white-space: normal !important;
   }
 }
+
+// The OBO-style "Short Id" for a class (e.g. GO:0008150), shown on its own
+// Details-pane row above the full IRI. Rendered with the standard chip styling
+// (same as synonyms) to stay visually conservative; the chip is a keyboard-
+// accessible copy control (click or Enter/Space copies the id).
+.obo-id {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.obo-id-copy {
+  cursor: pointer;
+  border-radius: 6px;
+  outline: none;
+
+  &:focus-visible {
+    box-shadow: 0 0 0 3px rgba(35, 73, 121, 0.35);
+  }
+}
+
+// The full IRI (the "Id" row) keeps its copy icon inline right after it, and
+// wraps naturally when long.
+.concept-id-iri {
+  word-break: break-all;
+
+  .clipboard {
+    display: inline-flex;
+    vertical-align: middle;
+    margin-left: 0.15rem;
+  }
+}
+
+// The preferred name is the class's primary label — show it in bold so it reads
+// as the main identity on the pane. (display_in_multiple_languages wraps it in a
+// <p>; keep that inline so the bold sits neatly in the row.)
+.concept-pref-name {
+  font-weight: 700;
+
+  p { display: inline; margin: 0; }
+}

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -64,6 +64,57 @@ module ComponentsHelper
     end
   end
 
+  # The short, community-facing "OBO-style" id for a class — e.g. "GO:0008150"
+  # for the IRI http://purl.obolibrary.org/obo/GO_0008150. Biomedical users refer
+  # to classes by this CURIE far more than by the full IRI.
+  #
+  # Prefer an explicit id/notation annotation on the class (the authoritative
+  # value); otherwise derive PREFIX:LOCAL from the IRI's last segment when it
+  # looks like an OBO/CURIE-style local name (PREFIX_LOCAL). Returns nil when the
+  # class has no such id, so callers can skip the pill entirely.
+  def obo_style_id(concept)
+    return nil if concept.nil?
+
+    annotated = obo_id_from_annotations(concept)
+    return annotated if annotated.present?
+
+    obo_id_from_iri(concept.id)
+  end
+
+  # Look for an id/notation annotation (e.g. oboInOwl#id, skos:notation) whose
+  # value is a CURIE like "GO:0008150".
+  def obo_id_from_annotations(concept)
+    props = concept.respond_to?(:properties) ? concept.properties : nil
+    return nil if props.nil? || !props.respond_to?(:members)
+
+    props.members.each do |key|
+      key_s = key.to_s
+      next unless key_s =~ %r{[#/](id|notation)\z}i
+
+      Array(props[key]).each do |value|
+        str = value.respond_to?(:object) ? value.object : value
+        str = str.to_s.strip
+        return str if str =~ /\A[A-Za-z][\w.-]*:\S+\z/
+      end
+    end
+    nil
+  end
+
+  # Derive PREFIX:LOCAL from the last IRI segment when it matches PREFIX_LOCAL
+  # (e.g. .../GO_0008150 -> GO:0008150). Only the first underscore is treated as
+  # the prefix separator, so local names containing underscores are preserved.
+  def obo_id_from_iri(iri)
+    return nil if iri.blank?
+
+    last = iri.to_s.include?('#') ? iri.to_s.split('#').last : iri.to_s.split('/').last
+    return nil if last.blank?
+
+    m = last.match(/\A([A-Za-z][A-Za-z0-9]*)_(.+)\z/)
+    return nil unless m
+
+    "#{m[1]}:#{m[2]}"
+  end
+
   def loader_component(type: 'pulsing', small: false)
     render LoaderComponent.new(type: type, small: small)
   end

--- a/app/views/concepts/_details.html.haml
+++ b/app/views/concepts/_details.html.haml
@@ -12,10 +12,25 @@
 
 
       - c.with_header(stripped: true) do |t|
-        - t.add_row({th: t('ontology_details.concept.id')}, {td:link_to_with_actions(@concept.id, acronym: @ontology.acronym)})
+        - obo_id = obo_style_id(@concept)
+        - if obo_id.present?
+          - t.add_row({th: t('ontology_details.concept.short_id', default: 'Short Id')}) do |h|
+            - h.td do
+              - copy_title = t('ontology_details.concept.copy_obo_id', default: 'Copy %{id}') % {id: obo_id}
+              %span.obo-id{data: {controller: 'clipboard'}}
+                %span.obo-id-copy{role: 'button', tabindex: '0', 'aria-label': copy_title, title: copy_title, data: {action: 'click->clipboard#copy keydown.enter->clipboard#copy keydown.space->clipboard#copy', 'clipboard-target': 'copy'}}
+                  = render ChipButtonComponent.new(text: obo_id, type: 'static')
+                %span.d-none{data: {'clipboard-target': 'check'}}
+                  = render ChipButtonComponent.new(text: t('components.copied', default: 'Copied!'), type: 'static')
+                %input{type: 'hidden', value: obo_id, data: {'clipboard-target': 'content'}}
+        - t.add_row({th: t('ontology_details.concept.id')}) do |h|
+          - h.td do
+            %span.concept-id-iri
+              = link_to_with_actions(@concept.id, acronym: @ontology.acronym)
         - t.add_row({th: t('ontology_details.concept.preferred_name')}) do |h|
           - h.td do
-            = display_in_multiple_languages(@concept.prefLabel)
+            %span.concept-pref-name
+              = display_in_multiple_languages(@concept.prefLabel)
 
         - unless @concept.definition.nil? || @concept.definition.empty?
           - t.add_row({th: t('ontology_details.concept.definitions')}, {td: display_in_multiple_languages(@concept.definition)})


### PR DESCRIPTION
# Show the class "Short Id" on the concept Details pane

On the Classes tab, the concept Details pane showed a class only by its full
IRI, e.g.:

> **Id**  `http://purl.obolibrary.org/obo/GO_0008150`

But people usually refer to a class by its short id — `GO:0008150`. In the
biomedical/OBO world that compact form is the identifier practitioners actually
recognise, cite, and search for, and it is far quicker to scan than the full
IRI. This PR surfaces it.

## What changed

A new **Short Id** row appears above the existing **Id** row:

> **Short Id**  `GO:0008150`
> **Id**  `http://purl.obolibrary.org/obo/GO_0008150`

- The Short Id is shown as a small chip (the same chip style already used for
  synonyms, so it fits the existing look). Clicking it — or focusing it and
  pressing Enter/Space — copies the id to the clipboard.
- The full IRI stays on its own **Id** row, with its copy icon as before.
- The **Preferred Name** is now shown in bold, as the class's primary label.

## Where the Short Id comes from

For each class, in order of preference:

1. Its own declared `id` / `notation` annotation (e.g. `oboInOwl:id`,
   `skos:notation`) — the authoritative value the ontology provides.
2. Otherwise, derived from the IRI when its last segment looks like a
   `PREFIX_LOCAL` id — e.g. `.../GO_0008150` → `GO:0008150`. Only the first
   underscore is treated as the prefix separator, so local names that contain
   underscores are preserved.

If a class has neither (an opaque or word-only IRI), the Short Id row is simply
not shown — there is no misleading or empty value.

## Scope

Small and self-contained: the browse template, one helper, and some CSS. It does
not change the data model or how classes are fetched, and it reuses the existing
chip and clipboard components.

## Testing

Checked against live data on the Classes tab: the Short Id renders for OBO-style
classes (e.g. `GO:0008150`), copies on click and via keyboard, the full IRI
still shows on the Id row, and classes without a short-form id show only the Id
row.
