### PR TITLE
Clear the unselected ontology location source on save

### DIFF
--- a/app/controllers/concerns/submission_updater.rb
+++ b/app/controllers/concerns/submission_updater.rb
@@ -123,7 +123,7 @@ module SubmissionUpdater
       attributes << m_attr
     end
     p = params.permit(attributes.uniq)
-    p['pullLocation'] = '' if p['isRemote']&.eql?('3')
+    p = clear_unselected_location_source(p)
 
     p = p.to_h.transform_values do |v|
       if v.is_a? Hash
@@ -151,5 +151,27 @@ module SubmissionUpdater
     end
 
     p
+  end
+
+  # The location form keeps the inputs for all three sources in the DOM and only
+  # hides the unselected ones, so a stale pull URL — or a file picked before the
+  # user changed their mind — is submitted along with the chosen source. Keep only
+  # the field that belongs to the selected source.
+  #
+  # pullLocation is blanked rather than dropped: the API clears a string attribute
+  # only when it receives an empty value, so omitting it would leave the old URL in
+  # place and the nightly pull would keep replacing the ontology. filePath is
+  # dropped instead, since it only takes effect when it carries an actual upload.
+  #
+  # An already-uploaded file still can't be detached here: uploadFilePath is
+  # system_controlled in the API, which drops it from any request. See
+  # https://github.com/ncbo/bioportal_web_ui/issues/435
+  def clear_unselected_location_source(permitted)
+    is_remote = permitted['isRemote']
+    return permitted if is_remote.blank?
+
+    permitted['pullLocation'] = '' unless is_remote.eql?('1')
+    permitted.delete('filePath') unless is_remote.eql?('0')
+    permitted
   end
 end

--- a/test/controllers/concerns/submission_updater_test.rb
+++ b/test/controllers/concerns/submission_updater_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests how submission_params handles the ontology location form. That form keeps
+# the inputs for all three sources (metadata only / pull URL / local file) in the
+# DOM and only hides the unselected ones, so every source's field is submitted on
+# every save. submission_params has to keep just the selected one.
+#
+# submission_metadata is stubbed to [] so these tests don't reach the API; the
+# location attributes under test are permitted explicitly, not via that list.
+class SubmissionUpdaterTest < ActiveSupport::TestCase
+  class Harness
+    include SubmissionUpdater
+
+    def submission_metadata
+      []
+    end
+
+    # submission_params is private; expose it for testing.
+    def permit(raw)
+      submission_params(ActionController::Parameters.new(raw))
+    end
+  end
+
+  setup do
+    @harness = Harness.new
+    @url = 'http://example.org/ontology.owl'
+  end
+
+  test 'keeps the pull URL when Load From Url is selected' do
+    result = @harness.permit(isRemote: '1', pullLocation: @url)
+
+    assert_equal @url, result['pullLocation']
+  end
+
+  test 'blanks a stale pull URL when Upload Local File is selected' do
+    result = @harness.permit(isRemote: '0', pullLocation: @url)
+
+    # Blank rather than absent: the API only clears a string attribute when it
+    # receives an empty value, so dropping the key would leave the old URL set.
+    assert_equal '', result['pullLocation']
+  end
+
+  test 'blanks a stale pull URL when Metadata Only is selected' do
+    result = @harness.permit(isRemote: '3', pullLocation: @url)
+
+    assert_equal '', result['pullLocation']
+  end
+
+  test 'drops a file picked before switching to Load From Url' do
+    result = @harness.permit(isRemote: '1', pullLocation: @url, filePath: 'ontology.owl')
+
+    assert_nil result['filePath']
+    assert_equal @url, result['pullLocation']
+  end
+
+  test 'keeps the file when Upload Local File is selected' do
+    result = @harness.permit(isRemote: '0', filePath: 'ontology.owl')
+
+    assert_equal 'ontology.owl', result['filePath']
+  end
+
+  test 'leaves the pull URL untouched when the location form was not submitted' do
+    # Editing a single unrelated attribute posts no isRemote, and must not be
+    # treated as a source change.
+    result = @harness.permit(pullLocation: @url, description: 'unchanged')
+
+    assert_equal @url, result['pullLocation']
+  end
+end


### PR DESCRIPTION
## Problem

An ontology's location can be a pull URL, an uploaded local file, or "metadata only". Switching from **Load from URL** to **Upload local file** didn't take: the old URL survived the save, so the nightly pull kept replacing the ontology with whatever was at the stale URL. This is the direction reported by @jonquet and @ckindermann in #435 — the latter as manual uploads being silently overwritten overnight.

There was also no way to "unplug" an ontology: remove a pull URL without supplying a replacement file.

## Cause

The location form keeps the inputs for all three sources in the DOM and only toggles `style.display` on the unselected ones. A `display:none` input is still submitted, so the stale pull URL was posted alongside the newly chosen source. `submission_params` blanked it for the metadata-only case only:

```ruby
p['pullLocation'] = '' if p['isRemote']&.eql?('3')
```

Nothing blanked it when the user picked a local file, so it persisted.

## Fix

Keep only the location field belonging to the selected source:

```ruby
permitted['pullLocation'] = '' unless is_remote.eql?('1')
permitted.delete('filePath') unless is_remote.eql?('0')
```

The asymmetry is deliberate:

- `pullLocation` is **blanked**, not dropped. The API clears a string attribute only when it receives an empty value, so omitting the key would leave the old URL in place.
- `filePath` is **dropped**, since it only has an effect when it carries an actual upload. This also prevents a file that was picked and then abandoned (user switched to *Load from URL* afterwards) from being uploaded anyway.

It's a no-op when `isRemote` isn't submitted, so editing a single unrelated attribute can't wipe a URL.

## Testing

Manual, against a live backend:

- Blanking the URL field on a **Load from URL** ontology clears it and sticks.
- Switching a URL-based ontology to **Upload local file** with a new file clears the URL and uploads the file.

Automated — six cases in `test/controllers/concerns/submission_updater_test.rb` covering each source selection, the abandoned-file case, and the no-`isRemote` case. `submission_metadata` is stubbed so the tests don't call the API. Verified that they fail without the fix (two failures; the metadata-only case still passes, confirming the previous code covered only that one).

## Scope

This fixes one direction. **The scenario in #435's title — Upload local file → Load from URL — is not fixed here**, and isn't fixable in this repo.

Switching to a URL sets `pullLocation`, but the submission's `uploadFilePath` still points at the previously uploaded file, and `ncbo_cron` only re-downloads when that file is *missing* — so the new URL is never fetched and the old file is parsed again. The UI can't intervene: the only way a request can affect `uploadFilePath` is by carrying an actual file upload, which the API converts to a path server-side. The field is `system_controlled`, so a request can't name it directly, and it shouldn't be blanked anyway — the submission and ontology download routes read it to locate the physical file.

The fix belongs server-side, as a refresh when the pull location changes rather than as a clear. Tracking separately.

One further upstream bug surfaced while investigating, worth its own issue: in `ontologies_api`, a PATCH that uploads a file never queues reprocessing. `request_has_file?` tests `v.instance_of?(Hash)` while `file_from_request` tests `v.is_a?(Hash)`; Sinatra params are `IndifferentHash < Hash`, so the strict check is always false. The upload is stored, but no job is queued.

Refs #435
