### PR TITLE
Preserve the active concept view when selecting a class (#533)

### DIFF
--- a/app/components/tabs_container_component.rb
+++ b/app/components/tabs_container_component.rb
@@ -6,11 +6,17 @@ class TabsContainerComponent < ViewComponent::Base
   renders_many :item_contents
   renders_one :pinned_right
 
-  def initialize(id: '', url_parameter: nil, type: 'primary')
+  # merge_url_params: when true, selecting a tab MERGES its url_parameter into the
+  # current query string (keeping the other params); when false (the default) it
+  # replaces the query string with just this tab's param. Merge is for tabs that
+  # coexist with other state — e.g. the concept views, which must keep `conceptid`.
+  # Replace is for tabs that own the query string — e.g. the top-level `p` sections.
+  def initialize(id: '', url_parameter: nil, type: 'primary', merge_url_params: false)
     super()
     @url_parameter = url_parameter
     @type = type
     @id = id
+    @merge_url_params = merge_url_params
   end
 
   def container_class
@@ -41,6 +47,10 @@ class TabsContainerComponent < ViewComponent::Base
       'tab-id': item.id,
       'tab-title': item.page_name,
       'url-parameter': @url_parameter,
+      # Emit an explicit string, not a Ruby boolean: Rails renders a `true` data value
+      # as a valueless attribute (data-url-merge=""), which the controller reads as ""
+      # and would treat as "replace". "true"/"false" makes the intent unambiguous.
+      'url-merge': @merge_url_params.to_s,
       action: 'click->tabs-container#selectTab'
     }
   end

--- a/app/components/tabs_container_component/tabs_container_component_controller.js
+++ b/app/components/tabs_container_component/tabs_container_component_controller.js
@@ -31,13 +31,27 @@ export default class extends Controller {
         return this.event.currentTarget.getAttribute("data-url-parameter")
     }
 
+    #merge() {
+        return this.event.currentTarget.getAttribute("data-url-merge") === "true"
+    }
 
     #url() {
         return `?${this.#parameter()}=${this.#pageId()}`
     }
 
     #updateURL() {
-        (new HistoryService()).pushState({[this.#parameter()]: this.#pageId()}, this.#title(), this.#url());
+        const history = new HistoryService();
+        if (this.#merge()) {
+            // Merge this tab's param into the current query string, keeping the other
+            // params. Used by tabs that coexist with other state — e.g. the concept
+            // views, which must keep `conceptid` when the view changes.
+            history.updateHistory(window.location.href, {[this.#parameter()]: this.#pageId()});
+        } else {
+            // Replace the query string with just this tab's param. Used by tabs that
+            // own the URL — e.g. the top-level `p` sections — so switching them leaves
+            // no stale params behind.
+            history.pushState({[this.#parameter()]: this.#pageId()}, this.#title(), this.#url());
+        }
     }
 
 }

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -191,9 +191,35 @@ module OntologiesHelper
     end
   end
 
+  # The tab ids of the inner concept views, in _show.html.haml order. The default
+  # (first) is used when the `view` param is missing or is not one of these — so a
+  # stale/typo'd/bogus value falls back to Details rather than leaving every tab
+  # deselected and the pane blank.
+  #
+  # These MUST stay in sync with the `id:` values of the tab_item_component calls in
+  # app/views/concepts/_show.html.haml. OntologiesHelperTest asserts that, so drift
+  # is caught by the test suite rather than shipping a silently-unselectable tab.
+  CONCEPT_VIEWS = %w[details visualization concept-notes concept-mappings].freeze
+
+  # Which inner concept view (Details / Visualization / Notes / Mappings) is active.
+  # Read from the `view` URL param so the selection survives a class change: the tree
+  # link reloads the concept_show frame, and without this the view always reset to
+  # Details (issue #533).
+  def current_concept_view
+    view = params[:view].presence
+    CONCEPT_VIEWS.include?(view) ? view : CONCEPT_VIEWS.first
+  end
+
+  def selected_concept_view?(view_id)
+    current_concept_view.eql?(view_id)
+  end
+
   def ontology_object_tabs_component(ontology_id:, objects_title:, object_id:, &block)
     resource_url = ontology_object_json_link(ontology_id, objects_title, object_id)
-    render TabsContainerComponent.new(type: 'outline') do |c|
+    # merge_url_params: keep the other query params (notably `conceptid`) when the
+    # view changes — the concept views coexist with the selected class, unlike the
+    # top-level `p` sections which own the URL.
+    render TabsContainerComponent.new(type: 'outline', url_parameter: 'view', merge_url_params: true) do |c|
       concat(c.with_pinned_right do
         content_tag(:div, '', class: 'd-flex', 'data-concepts-json-target': 'button') do
           concat(render_permalink_link) if $PURL_ENABLED

--- a/app/helpers/ontologies_helper.rb
+++ b/app/helpers/ontologies_helper.rb
@@ -214,12 +214,13 @@ module OntologiesHelper
     current_concept_view.eql?(view_id)
   end
 
-  def ontology_object_tabs_component(ontology_id:, objects_title:, object_id:, &block)
+  # url_parameter/merge_url_params default to leaving the URL alone; only the concept
+  # views opt in (see concepts/_show.html.haml).
+  def ontology_object_tabs_component(ontology_id:, objects_title:, object_id:,
+                                     url_parameter: nil, merge_url_params: false, &block)
     resource_url = ontology_object_json_link(ontology_id, objects_title, object_id)
-    # merge_url_params: keep the other query params (notably `conceptid`) when the
-    # view changes — the concept views coexist with the selected class, unlike the
-    # top-level `p` sections which own the URL.
-    render TabsContainerComponent.new(type: 'outline', url_parameter: 'view', merge_url_params: true) do |c|
+    render TabsContainerComponent.new(type: 'outline', url_parameter: url_parameter,
+                                      merge_url_params: merge_url_params) do |c|
       concat(c.with_pinned_right do
         content_tag(:div, '', class: 'd-flex', 'data-concepts-json-target': 'button') do
           concat(render_permalink_link) if $PURL_ENABLED

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -2,6 +2,21 @@ import { Controller } from '@hotwired/stimulus'
 
 const TREE_VIEW_PAGES = ['classes', 'properties', 'schemes', 'collections', 'instances']
 
+// Carry the active concept view (the `view` URL param) into the concept_show frame
+// request that Turbo fires when a class is selected in the tree, so the view is
+// preserved instead of resetting to Details (issue #533). Handled at fetch time
+// (rather than rewriting the tree link's href) to avoid races with Turbo's own
+// click handling. Registered once at the document level — it's stateless (reads only
+// the event and window.location) and idempotent, so it never needs per-controller
+// setup/teardown and can't be double-registered no matter how many trees mount.
+document.addEventListener('turbo:before-fetch-request', (event) => {
+  if (event.target?.id !== 'concept_show') return // only the concept view frame
+  const view = new URLSearchParams(window.location.search).get('view')
+  if (!view) return
+  const url = event.detail?.url
+  if (url && !url.searchParams.has('view')) url.searchParams.set('view', view)
+})
+
 // Connects to data-controller="simple-tree"
 export default class extends Controller {
 

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -16,20 +16,23 @@
         -# prefixed with "concept-" because the ontology-level Notes and Mappings
         -# sections already render #notes_content / #mappings_content wrappers,
         -# and both sections can be in the DOM at once (hidden, not removed).
-        - tab_item_component(container_tabs: c, id: 'details', title: t('concepts.details'), path: '#details', selected: true, json_link: "#{baseClassUrl}?#{apikey}&display=all") do
+        -# `selected:` is driven by the `view` URL param (see current_concept_view)
+        -# so the active view is preserved when a different class is selected in the
+        -# tree, instead of always resetting to Details (issue #533).
+        - tab_item_component(container_tabs: c, id: 'details', title: t('concepts.details'), path: '#details', selected: selected_concept_view?('details'), json_link: "#{baseClassUrl}?#{apikey}&display=all") do
           = render :partial =>'/concepts/details'
 
-        - tab_item_component(container_tabs: c, id: 'visualization', title: t('concepts.visualization'), path: '#visualization') do
+        - tab_item_component(container_tabs: c, id: 'visualization', title: t('concepts.visualization'), path: '#visualization', selected: selected_concept_view?('visualization')) do
           = render :partial =>'/concepts/biomixer'
 
 
         - count_span = content_tag(:span, "#{t('concepts.notes')} (#{content_tag(:span, @notes.length, id: 'note_count')})".html_safe)
-        - tab_item_component(container_tabs: c, id: 'concept-notes', title: count_span, path: '#notes', json_link: "#{baseClassUrl}/notes?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'concept-notes', title: count_span, path: '#notes', selected: selected_concept_view?('concept-notes'), json_link: "#{baseClassUrl}/notes?#{apikey}") do
           = render :partial =>'/notes/list'
 
 
         - count_span = content_tag(:span, "#{t('concepts.mappings')} (#{content_tag(:span, concept_mappings_loader(ontology_acronym: @ontology.acronym, concept_id: @concept.id))})".html_safe, class: "d-flex")
-        - tab_item_component(container_tabs: c, id: 'concept-mappings', title: count_span, path: '#mappings', json_link: "#{baseClassUrl}/mappings?#{apikey}") do
+        - tab_item_component(container_tabs: c, id: 'concept-mappings', title: count_span, path: '#mappings', selected: selected_concept_view?('concept-mappings'), json_link: "#{baseClassUrl}/mappings?#{apikey}") do
           = render TurboFrameComponent.new(id:'concept_mappings',
           src:"/ajax/mappings/get_concept_table?ontologyid=#{@ontology.acronym}&conceptid=#{CGI.escape(@concept.id)}")
 

--- a/app/views/concepts/_show.html.haml
+++ b/app/views/concepts/_show.html.haml
@@ -5,7 +5,9 @@
         = t('concepts.use_jump_to')
   - else
     %div{'data-controller': 'concepts-json', 'data-action': 'click->concepts-json#update'}
-      = ontology_object_tabs_component(ontology_id: @ontology.acronym, objects_title: "classes", object_id: @concept.id) do |c|
+      -# Record the active view in a `view` param, merged into the current query string
+      -# so it survives a class change and `conceptid` is kept (issue #533).
+      = ontology_object_tabs_component(ontology_id: @ontology.acronym, objects_title: "classes", object_id: @concept.id, url_parameter: 'view', merge_url_params: true) do |c|
         - apikey = "apikey=#{get_apikey}"
         - baseClassUrl = "#{@ontology.id}/classes/#{escape(@concept.id)}"
         -# Pass explicit ids: without one, TabItemComponent derives the item id

--- a/test/helpers/ontologies_helper_test.rb
+++ b/test/helpers/ontologies_helper_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class OntologiesHelperTest < ActionView::TestCase
+  tests OntologiesHelper
+
+  # current_concept_view / selected_concept_view? drive which concept view (Details /
+  # Visualization / Notes / Mappings) is active from the `view` URL param, so the
+  # selection survives a class change instead of always resetting to Details (#533).
+
+  test 'current_concept_view defaults to details when the view param is absent' do
+    assert_equal 'details', current_concept_view
+  end
+
+  test 'current_concept_view returns a recognised view param' do
+    params[:view] = 'visualization'
+    assert_equal 'visualization', current_concept_view
+  end
+
+  test 'current_concept_view falls back to details for an unknown view param' do
+    params[:view] = 'bogus'
+    assert_equal 'details', current_concept_view,
+                 'an unrecognised ?view=... must fall back to details, not leave every tab deselected'
+  end
+
+  test 'current_concept_view falls back to details for a blank view param' do
+    params[:view] = ''
+    assert_equal 'details', current_concept_view
+  end
+
+  test 'selected_concept_view? matches only the active view' do
+    params[:view] = 'concept-notes'
+    assert selected_concept_view?('concept-notes')
+    refute selected_concept_view?('details')
+    refute selected_concept_view?('visualization')
+  end
+
+  # Guards the coupling flagged in code review: CONCEPT_VIEWS must list exactly the
+  # tab ids rendered by _show.html.haml (in order). If a tab is added/renamed there
+  # without updating the constant, its ?view=... value wouldn't be whitelisted and
+  # the tab could never be the active view via URL — this fails loudly instead.
+  test 'CONCEPT_VIEWS stays in sync with the tab ids in concepts/_show.html.haml' do
+    show = Rails.root.join('app', 'views', 'concepts', '_show.html.haml').read
+    rendered_ids = show.scan(/tab_item_component\([^)]*\bid:\s*'([^']+)'/).flatten
+    assert_equal OntologiesHelper::CONCEPT_VIEWS, rendered_ids,
+                 'OntologiesHelper::CONCEPT_VIEWS must match (and be ordered like) the ' \
+                 'tab_item_component id: values in concepts/_show.html.haml'
+  end
+end


### PR DESCRIPTION
## Summary

On an ontology's Classes page, selecting a different class in the left-hand tree
reset the right-hand view back to **Details**, even when another view
(Visualization / Notes / Mappings) was open. This preserves the active view across
class selections. Fixes #533.

## Root cause

Selecting a class reloads the `concept_show` Turbo frame, and
`concepts/_show.html.haml` hard-coded `selected: true` on the Details tab — so
every reload rebuilt the pane with Details active, regardless of the previously
open view. The active view wasn't tracked anywhere.

## What changed

Persist the active view in a `view` URL param and read it back server-side:

- Give the concept tabs `url_parameter: 'view'` so selecting a view records it.
- Drive each tab's `selected:` from `selected_concept_view?` (defaults to
  `details`) instead of hard-coding Details.
- Carry the current `view` param into the `concept_show` frame request on class
  select, via a document-level `turbo:before-fetch-request` hook (race-free
  compared with rewriting the link href; registered once, stateless, idempotent).

### Guarding against a blank pane

Each tab decides on its own whether it's active — its `selected:` is
`selected_concept_view?('<its id>')`, i.e. "is the current view *my* id?". Nothing
guarantees that *some* tab matches. So if the `view` param is a value no tab has
(a typo, a stale link from before a view was renamed, a hand-edited URL), then
every tab's check returns false, no tab is marked active, and the right-hand pane
renders **completely blank** — no active tab, no content.

To prevent that, `current_concept_view` doesn't return the raw param. It validates
it against the known view ids (`CONCEPT_VIEWS`) and returns `details` whenever the
param is missing **or** not one of them. So an unrecognised `?view=…` degrades to
the Details view instead of a blank pane, and only a genuinely valid value selects
a non-default view.

`TabsContainerComponent` gains an opt-in `merge_url_params` flag rather than
changing URL behaviour globally:

- **merge** (concept views): keep the other query params — notably `conceptid` —
  when the view changes.
- **replace** (default; top-level `p` sections, submission `section` tabs):
  switching a tab still yields a clean single-param URL with no stale leftovers.

The flag is emitted as an explicit `"true"`/`"false"` string because Rails renders
a boolean data value as a valueless attribute, which the controller would
otherwise misread.

The view is now deep-linkable — e.g. `?view=concept-mappings` opens Mappings
directly.

## Tests

Adds `test/helpers/ontologies_helper_test.rb` covering the default / valid / bogus
/ blank param cases, and asserting `CONCEPT_VIEWS` stays in sync with the tab ids
rendered by `concepts/_show.html.haml` (so adding/renaming a view can't silently
ship an unselectable tab).

## Verification

Verified manually in a browser:

- Visualization / Notes / Mappings each survive a class change (URL keeps `p` +
  `conceptid` + `view`).
- Default (no param) and a bogus `?view=` both fall back to Details.
- Deep links open the right view.
- Top-level `p` section tabs still produce a clean `?p=…` with no stale params.

## Coverage caveat / follow-up

There's no automated **browser/system test** for the Turbo + Stimulus round-trip
(the literal issue behaviour). The test suite doesn't currently run in the dev
environment — it's missing the test config (`config/bioportal_config_test.rb`), so
`bin/rails test` won't start, and there's no Capybara system-test setup. Rather
than add a browser test that can't be run and confirmed here, the gap is logged as
a deliberate follow-up: add a "select Mappings → click another class → Mappings
stays active" system test once the test environment is runnable.

## Upstream

The same bug is present in `ontoportal/ontoportal_web_ui` (also tracked at
ontoportal/ontoportal_web_ui#75). This patch doesn't port cleanly — upstream's
concept tabs have no `id:`, include an extra `instances` tab, and build their
`json_link`s differently — so an adapted upstream PR is a separate follow-up
rather than part of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
