### PR TITLE
Hanging-indent wrapped class-tree labels beside the chevron (#534)

### DIFF
--- a/app/assets/stylesheets/components/tree_view.scss
+++ b/app/assets/stylesheets/components/tree_view.scss
@@ -21,7 +21,7 @@ div.tree_error {
 
 #bd ul.simpleTree li {
     margin-left: 0;
-    padding: 5px 0 0 10px;
+    padding: 3px 0 0 10px;
 }
 
 #bd ul.simpleTree {
@@ -33,9 +33,51 @@ div.tree_error {
     margin: 0;
     padding: 0;
 
+    // The chevron and the label share a flex row so that a label wrapping to
+    // more than one line stays in the label column (hanging-indented beside the
+    // chevron) instead of dropping back to the li's left edge, below the handle.
+    .tree-row {
+        display: flex;
+        align-items: flex-start;
+
+        // Chevron column: a <turbo_frame> wrapping the expand link when
+        // collapsed, or a bare rotated <svg> when expanded. It's a fixed-width
+        // column that neither grows nor shrinks, vertically centred on the
+        // label's first line. The fixed width also makes the label text start
+        // at the same x whether or not a chevron is present: leaf rows (no
+        // chevron) indent their label with Bootstrap's .ps-3, and this column
+        // plus the label's own left padding reserve the matching space here.
+        > turbo_frame,
+        > .tree-chevron {
+            flex: 0 0 auto;
+            margin-top: 5px;
+        }
+
+        // Collapsed chevron: <turbo_frame> wrapping the ~10px expand link.
+        > turbo_frame {
+            width: 15px;
+        }
+
+        // Expanded chevron: a bare <svg> that becomes a direct flex item; as a
+        // flex item its height:1em is treated as a flex-basis and gets squashed,
+        // so pin the height. Its glyph is ~10px wide; a 5px right margin makes
+        // its column the same 15px as the collapsed state.
+        > .tree-chevron {
+            height: 1em;
+            width: auto;
+            margin-right: 5px;
+            align-self: flex-start;
+        }
+    }
+
     a.tree-link {
         display: inline-block;
-        padding: 5px;
+        flex: 1 1 auto;
+        min-width: 0;
+        // Every label carries the active state's padding so that selecting a
+        // node only adds the highlight background (below) — the box size never
+        // changes, so the row doesn't jiggle on selection.
+        padding: 6px 5px;
         text-wrap: wrap;
         color: var(--primary-color) !important;
     }
@@ -43,9 +85,12 @@ div.tree_error {
     a.tree-link.active {
         cursor: default;
         background-color: var(--light-color);
-        font-weight: bold;
         border-radius: 3px;
-        padding: 7px 5px;
+        // Emphasise the selected node without a real font-weight change, which
+        // would widen the glyphs and make the row reflow/jiggle on selection.
+        // -webkit-text-stroke thickens the strokes in place, keeping glyph
+        // advance widths identical to the unselected state.
+        -webkit-text-stroke: 0.4px currentColor;
     }
 
     .tree-border-left {

--- a/app/assets/stylesheets/components/tree_view.scss
+++ b/app/assets/stylesheets/components/tree_view.scss
@@ -77,7 +77,12 @@ div.tree_error {
         // Every label carries the active state's padding so that selecting a
         // node only adds the highlight background (below) — the box size never
         // changes, so the row doesn't jiggle on selection.
-        padding: 6px 5px;
+        padding: 3px 5px;
+        // The surrounding .simpleTree li sets line-height:14px, which is tighter
+        // than the 16px text and cramps labels that wrap to more than one line.
+        // Restore a readable line-height here; the reduced padding above keeps
+        // single-line rows the same compact height.
+        line-height: 1.25;
         text-wrap: wrap;
         color: var(--primary-color) !important;
     }

--- a/app/components/tree_link_component/tree_link_component.html.haml
+++ b/app/components/tree_link_component/tree_link_component.html.haml
@@ -1,14 +1,15 @@
 %li{id:li_id , class: open?}
-  = open_children_link
-  - if @open_in_modal
-    =  link_to_modal(@pref_label_html, @href,  data: { show_modal_size_value: 'modal-xl' } )
-  - else
-    %a{id: @child.id, data: @data, title:  @tooltip,
-              href: @href, class: "tree-link #{@muted_style} #{@active_style} #{border_left} #{open?}"}
-      = @pref_label_html
-      - if @is_reused
-        .tree-view-reuse-icon
-          = helpers.inline_svg_tag 'icons/reuses.svg'
+  .tree-row
+    = open_children_link
+    - if @open_in_modal
+      =  link_to_modal(@pref_label_html, @href,  data: { show_modal_size_value: 'modal-xl' } )
+    - else
+      %a{id: @child.id, data: @data, title:  @tooltip,
+                href: @href, class: "tree-link #{@muted_style} #{@active_style} #{border_left} #{open?}"}
+        = @pref_label_html
+        - if @is_reused
+          .tree-view-reuse-icon
+            = helpers.inline_svg_tag 'icons/reuses.svg'
   - if @child.hasChildren && !@child.expanded?
     = render TurboFrameComponent.new(id: "#{child_id}_childs")
   - elsif @child.expanded?

--- a/app/javascript/controllers/simple_tree_controller.js
+++ b/app/javascript/controllers/simple_tree_controller.js
@@ -21,9 +21,12 @@ export default class extends Controller {
 
   toggleChildren (event) {
     event.preventDefault()
-    // currentTarget is the SVG the action is bound to; target can be its inner <path>
+    // currentTarget is the chevron SVG the action is bound to.
     event.currentTarget.classList.toggle('open')
-    event.currentTarget.nextElementSibling.nextElementSibling.classList.toggle('hidden')
+    // The children container is the sibling that follows the node's .tree-row
+    // (the chevron and label live inside that row, not directly under the li).
+    const row = event.currentTarget.closest('.tree-row')
+    row?.nextElementSibling?.classList.toggle('hidden')
   }
 
   #centerTreeView() {


### PR DESCRIPTION
Fixes #534.

## What

When a class label in the class tree wraps to more than one line, the wrapped lines dropped back to the left edge of the `<li>`, below the expand/collapse handle, instead of hanging-indented beside it in the label column.

## Changes

- **`tree_link_component.html.haml`** — wrap the chevron (`open_children_link`) and the label in a `.tree-row` div. The children container stays a direct child of the `<li>`, a sibling of `.tree-row`, so tree nesting is unchanged.
- **`tree_view.scss`** — make `.tree-row` a flex row so a wrapping label stays in its own column (hanging-indented beside the chevron). Along the way:
  - Give the chevron a fixed-width column, vertically centred on the label's first line, so label text starts at the same x whether or not a row has a chevron (leaf rows keep their `.ps-3` indent).
  - Pin the expanded (bare `<svg>`) chevron's height so flex no longer flattens its aspect ratio.
  - Emphasise the selected node with `-webkit-text-stroke` instead of `font-weight: bold`, and carry the active padding on every label, so selecting a node no longer changes the box size and the row no longer jiggles.
  - Give wrapped labels a readable `line-height` (the surrounding `.simpleTree li` sets `line-height: 14px`, tighter than the 16px text) and trim the row padding to keep single-line rows compact.
- **`simple_tree_controller.js`** — `toggleChildren` located the children container by walking `chevron.nextElementSibling.nextElementSibling`. The `.tree-row` wrapper moved the children container to be a sibling of the row rather than of the chevron, so that walk landed on `null` and threw when collapsing a node in place. Locate the container relative to the row instead (`chevron.closest('.tree-row').nextElementSibling`).

## Testing

Verified in-browser against UBERON (Classes tree):

- Wrapping labels (e.g. `pharyngeal arch mesenchyme from head mesenchyme`) hang-indent beside the chevron; no line drops below the handle.
- Single-line rows, leaf indentation, and label left-alignment are unchanged (label text starts at the same x with or without a chevron, at every depth).
- Collapsed (`>`) and expanded (`⌄`) chevrons render the same size and are centred on the label's first line.
- Selecting a node causes no layout shift (width/height/left and neighbouring rows unchanged) and no double-image.
- Expand → collapse → re-expand cycles work with no console errors, via both the server-side turbo-frame expand and the client-side `toggleChildren` collapse.

The change affects only the ViewComponent-based tree (`.simpleTree` / `TreeLinkComponent`), used by the Classes and Collections trees and the infinite-scroll tree. The Properties tree uses a separate legacy `ncboTree` widget and is untouched.

